### PR TITLE
chore: CI Discord 봇 이름 EveryGSM으로 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           title: '✅ CI 성공'
           status: success
           content: 'PR을 확인해주세요.'
-          username: datagsm-front bot
+          username: EveryGSM-front bot
           color: 0x4CAF50
 
       - name: Failure Discord Notification
@@ -54,5 +54,5 @@ jobs:
           title: '❌ CI 실패'
           content: '에러를 확인해주세요.'
           status: failure
-          username: datagsm-front bot
+          username: EveryGSM-front bot
           color: 0xe74c3c


### PR DESCRIPTION
## 개요 💡

CI Discord 알림 봇의 이름이 `datagsm-front bot`으로 되어 있어 `EveryGSM-front bot`으로 변경했습니다.

## 작업내용 ⌨️

- ci.yml의 Discord 알림 봇 이름을 `datagsm-front bot` → `EveryGSM-front bot`으로 변경