### PR TITLE
[feat] 메인페이지 로그인 유도 토스트창 UI 적용

### DIFF
--- a/src/app/callback/page.tsx
+++ b/src/app/callback/page.tsx
@@ -39,12 +39,14 @@ const CallbackContent = () => {
         const { data: signInData } = await signIn({ authCode, redirectUri, codeVerifier });
 
         setCookie(COOKIE_KEYS.ACCESS_TOKEN, signInData.accessToken);
+        sessionStorage.setItem('login_success', 'true');
 
         router.replace('/');
       } catch (error) {
         const message = error instanceof Error ? error.message : '로그인 중 오류가 발생했습니다.';
 
         setErrorMessage(message);
+        sessionStorage.setItem('login_error', 'true');
 
         setTimeout(() => {
           router.replace('/');

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from 'next';
-import { Toaster } from 'sonner';
 
 import { getUserInfo } from '@/entities/auth/index.server';
 import { TanStackProvider } from '@/shared/lib';
 import { pretendard } from '@/shared/styles';
 import { ModalContainer } from '@/shared/ui';
+import AppToaster from '@/shared/ui/AppToaster';
 import { Header } from '@/widgets/header';
 
 import '@/shared/styles/globals.css';
@@ -27,7 +27,7 @@ const RootLayout = async ({
         <TanStackProvider>
           <Header initialUserInfoData={initialUserInfoData} />
           {children}
-          <Toaster position="bottom-right" richColors />
+          <AppToaster />
           <ModalContainer />
         </TanStackProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { getUserInfo } from '@/entities/auth/index.server';
 import { TanStackProvider } from '@/shared/lib';
 import { pretendard } from '@/shared/styles';
 import { ModalContainer } from '@/shared/ui';
-import AppToaster from '@/shared/ui/AppToaster';
+import { AppToaster } from '@/shared/ui';
 import { Header } from '@/widgets/header';
 
 import '@/shared/styles/globals.css';

--- a/src/features/like-project/ui/LikeButton.tsx
+++ b/src/features/like-project/ui/LikeButton.tsx
@@ -84,7 +84,7 @@ const LikeButton = ({ isLiked, projectId }: LikeButtonProps) => {
 
   const handleClick = () => {
     if (!isLoggedIn) {
-      toast.error('로그인이 필요한 기능입니다.');
+      toast.warning('로그인이 필요한 기능입니다.');
       return;
     }
     toggleLike(localIsLiked);

--- a/src/features/like-project/ui/LikeButton.tsx
+++ b/src/features/like-project/ui/LikeButton.tsx
@@ -84,7 +84,7 @@ const LikeButton = ({ isLiked, projectId }: LikeButtonProps) => {
 
   const handleClick = () => {
     if (!isLoggedIn) {
-      toast.warning('로그인이 필요한 기능입니다.');
+      toast.error('로그인이 필요한 기능입니다.');
       return;
     }
     toggleLike(localIsLiked);

--- a/src/shared/ui/AppToaster.tsx
+++ b/src/shared/ui/AppToaster.tsx
@@ -10,8 +10,6 @@ const AppToaster = () => {
       position="top-right"
       style={{ top: '80px' }}
       closeButton
-      expand={false}
-      richColors={false}
       toastOptions={{
         duration: 4500,
         style: {

--- a/src/shared/ui/AppToaster.tsx
+++ b/src/shared/ui/AppToaster.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Toaster } from 'sonner';
+
+import { cn } from '@/shared/utils';
+
+const AppToaster = () => {
+  return (
+    <Toaster
+      position="top-right"
+      style={{ top: '80px' }}
+      closeButton
+      expand={false}
+      richColors={false}
+      toastOptions={{
+        duration: 4500,
+        style: {
+          background: '#1b1b1b',
+          border: '1px solid #2F2F2F',
+          color: '#ff4d4f',
+          fontWeight: 600,
+        },
+        classNames: {
+          toast: cn('relative pr-10'),
+          icon: cn('text-[#ff4d4f]'),
+          closeButton: cn(
+            '!left-auto !right-[-4px] !top-2',
+            '!bg-transparent !border-none !shadow-none',
+            '!text-[#666666] hover:!bg-transparent',
+          ),
+        },
+      }}
+    />
+  );
+};
+
+export default AppToaster;

--- a/src/shared/ui/AppToaster.tsx
+++ b/src/shared/ui/AppToaster.tsx
@@ -20,7 +20,6 @@ const AppToaster = () => {
           fontWeight: 600,
         },
         classNames: {
-          toast: cn('relative pr-10'),
           success: cn('!text-[#7eff57] [&_[data-sonner-icon]]:text-[#52c41a]'),
           error: cn('!text-[#ff4d4f] [&_[data-sonner-icon]]:text-[#ff4d4f]'),
           warning: cn('!text-[#ffd049] [&_[data-sonner-icon]]:text-[#faad14]'),

--- a/src/shared/ui/AppToaster.tsx
+++ b/src/shared/ui/AppToaster.tsx
@@ -21,6 +21,7 @@ const AppToaster = () => {
           success: cn('!text-[#7eff57] [&_[data-sonner-icon]]:text-[#52c41a]'),
           error: cn('!text-[#ff4d4f] [&_[data-sonner-icon]]:text-[#ff4d4f]'),
           warning: cn('!text-[#ffd049] [&_[data-sonner-icon]]:text-[#faad14]'),
+          info: cn('!text-[#4dabf7] [&_[data-sonner-icon]]:text-[#339af0]'),
           closeButton: cn(
             '!left-auto !right-[-4px] !top-2',
             '!bg-transparent !border-none !shadow-none',

--- a/src/shared/ui/AppToaster.tsx
+++ b/src/shared/ui/AppToaster.tsx
@@ -17,12 +17,13 @@ const AppToaster = () => {
         style: {
           background: '#1b1b1b',
           border: '1px solid #2F2F2F',
-          color: '#ff4d4f',
           fontWeight: 600,
         },
         classNames: {
           toast: cn('relative pr-10'),
-          icon: cn('text-[#ff4d4f]'),
+          success: cn('!text-[#7eff57] [&_[data-sonner-icon]]:text-[#52c41a]'),
+          error: cn('!text-[#ff4d4f] [&_[data-sonner-icon]]:text-[#ff4d4f]'),
+          warning: cn('!text-[#ffd049] [&_[data-sonner-icon]]:text-[#faad14]'),
           closeButton: cn(
             '!left-auto !right-[-4px] !top-2',
             '!bg-transparent !border-none !shadow-none',

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,2 +1,3 @@
+export { default as AppToaster } from './AppToaster';
 export { default as ModalContainer } from './ModalContainer';
 export { default as SuspenseFallback } from './SuspenseFallback';

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { useEffect } from 'react';
+
+import { toast } from 'sonner';
+
 import { useGetUserInfo, UserInfoResponseType } from '@/entities/auth';
 import { ProjectsListResponseType, useGetProjects } from '@/entities/project';
 import { COOKIE_KEYS } from '@/shared/constants';
@@ -29,6 +33,18 @@ const HomePage = ({ initialUserInfoData, initialProjectsData }: HomePageProps) =
     errorType: 'forbidden-admin',
     message: '관리자 권한이 필요한 페이지입니다.',
   });
+
+  useEffect(() => {
+    if (sessionStorage.getItem('login_success')) {
+      toast.success('로그인에 성공했습니다.');
+      sessionStorage.removeItem('login_success');
+    }
+
+    if (sessionStorage.getItem('login_error')) {
+      toast.error('로그인에 실패했습니다.');
+      sessionStorage.removeItem('login_error');
+    }
+  }, []);
 
   return (
     <main className="min-h-[calc(100vh-72px)] bg-[#191919]">


### PR DESCRIPTION
## 개요 💡

메인페이지 로그인 유도 토스트창 UI를 추가하고 스타일을 적용했습니다.
toast.warning 사용 시 아이콘이 자동으로 표시되도록 변경되었습니다.

## 작업내용 ⌨️

- 토스트 UI 추가 및 스타일 적용
- warning 아이콘 표시


## 스크린샷/동영상 📸
**변경 전 디자인**
<img width="422" height="200" alt="image" src="https://github.com/user-attachments/assets/80c490ba-6245-495e-961b-8e07b638deb3" />



**변경 후 디자인**
<img width="422" height="141" alt="image" src="https://github.com/user-attachments/assets/2b38930a-0483-42b0-a68e-6a6327aa5b1d" />

디자이너분의 컨펌을 통해 경고 SVG가 추가되었습니다.


## 관련 이슈 🚨

Closes #27