### PR TITLE
[fix] 프로젝트 API 타입 정합성과 상세 응답 처리 수정

### DIFF
--- a/src/app/mypage/request/[id]/page.tsx
+++ b/src/app/mypage/request/[id]/page.tsx
@@ -1,14 +1,7 @@
 import { notFound, redirect } from 'next/navigation';
 
-import { ProjectResponseType } from '@/entities/project';
 import { getMyProject } from '@/entities/project/index.server';
 import { ProjectRequestDetailPage } from '@/views/project-request-detail';
-
-const isProjectResponse = (
-  data: Awaited<ReturnType<typeof getMyProject>>,
-): data is ProjectResponseType => {
-  return Boolean(data && 'data' in data);
-};
 
 const ProjectRequestDetail = async ({ params }: { params: Promise<{ id: string }> }) => {
   const { id } = await params;
@@ -20,20 +13,12 @@ const ProjectRequestDetail = async ({ params }: { params: Promise<{ id: string }
 
   const initialProjectData = await getMyProject(projectId);
 
-  if (!initialProjectData) {
-    redirect('/mypage');
-  }
-
   if (initialProjectData?.code === 403) {
     redirect('/mypage?error=forbidden');
   }
 
   if (initialProjectData?.code === 404) {
     notFound();
-  }
-
-  if (!isProjectResponse(initialProjectData)) {
-    redirect('/mypage');
   }
 
   return <ProjectRequestDetailPage projectId={projectId} initialProjectData={initialProjectData} />;

--- a/src/entities/project/api/getMyProject.ts
+++ b/src/entities/project/api/getMyProject.ts
@@ -1,13 +1,10 @@
 import { projectUrl } from '@/shared/api';
 import { apiFetcher } from '@/shared/api/fetcher';
-import { BaseApiResponse } from '@/shared/types';
 
 import { ProjectResponseType } from '../model/types';
 
-export const getMyProject = async (
-  id: number,
-): Promise<ProjectResponseType | BaseApiResponse | undefined> => {
-  return apiFetcher<ProjectResponseType | BaseApiResponse>({
+export const getMyProject = async (id: number): Promise<ProjectResponseType | undefined> => {
+  return apiFetcher<ProjectResponseType>({
     endpoint: projectUrl.getMyProject(id),
     context: 'getMyProject',
     errorMessage: '마이페이지 프로젝트 조회 실패:',

--- a/src/entities/project/model/types.ts
+++ b/src/entities/project/model/types.ts
@@ -6,10 +6,6 @@ export interface TechStackType {
   stackName: string;
 }
 
-export interface ProjectRepositoryReqType {
-  repoUrl: string;
-}
-
 export interface ProjectRepositoryType {
   repoName: string;
   repoUrl: string;
@@ -19,11 +15,11 @@ export interface ProjectType {
   projectId: number;
   logo: string;
   title: string;
-  affiliation: string;
+  affiliation: string | null;
   description: string;
   prodUrl: string;
   status: StatusType;
-  reason: string;
+  reason: string | null;
   createdAt: string;
   techStack: TechStackType[];
   repository: ProjectRepositoryType[];
@@ -35,9 +31,9 @@ export interface ProjectRegisterReqType {
   title: string;
   affiliation: string;
   description: string;
-  prodUrl: string;
+  prodUrl?: string;
   techStack: TechStackType[];
-  repository: ProjectRepositoryReqType[];
+  repository?: string[];
 }
 
 export type ProjectResponseType = ApiResponse<ProjectType>;

--- a/src/entities/project/ui/ProjectCard.tsx
+++ b/src/entities/project/ui/ProjectCard.tsx
@@ -16,6 +16,7 @@ interface ProjectCardProps {
 
 const ProjectCard = ({ data, likeButton, onDetailClick }: ProjectCardProps) => {
   const { logo, title, affiliation, description, techStack, prodUrl } = data;
+  const displayAffiliation = affiliation ?? '소속 정보 없음';
 
   const [isCenterHover, setIsCenterHover] = useState(false);
 
@@ -63,7 +64,9 @@ const ProjectCard = ({ data, likeButton, onDetailClick }: ProjectCardProps) => {
         >
           <div className={cn('flex flex-col gap-y-2')}>
             <h3 className={cn('text-xl leading-6 font-semibold text-white')}>{title}</h3>
-            <p className={cn('text-sm leading-4.25 font-medium text-[#9A9A9A]')}>{affiliation}</p>
+            <p className={cn('text-sm leading-4.25 font-medium text-[#9A9A9A]')}>
+              {displayAffiliation}
+            </p>
           </div>
           <div className={cn('line-clamp-2 h-9 text-xs leading-4.5 font-medium text-[#9A9A9A]')}>
             {description}

--- a/src/entities/project/ui/ProjectDetailModal.tsx
+++ b/src/entities/project/ui/ProjectDetailModal.tsx
@@ -15,6 +15,7 @@ interface ProjectDetailModalProps {
 const ProjectDetailModal = ({ data, modalLikeButton }: ProjectDetailModalProps) => {
   const { logo, title, affiliation, description, techStack, prodUrl, repository } = data;
   const { closeModal } = useModalStore();
+  const displayAffiliation = affiliation ?? '소속 정보 없음';
 
   return (
     <div
@@ -35,7 +36,7 @@ const ProjectDetailModal = ({ data, modalLikeButton }: ProjectDetailModalProps) 
           <h3 className={cn('text-4xl leading-10.75 font-bold text-white')}>{title}</h3>
           {modalLikeButton}
         </div>
-        <p className={cn('text-xl leading-6 font-medium text-[#DDDDDD]')}>{affiliation}</p>
+        <p className={cn('text-xl leading-6 font-medium text-[#DDDDDD]')}>{displayAffiliation}</p>
       </div>
       <div className={cn('flex flex-col gap-y-4')}>
         <p className={cn('text-base leading-6 font-medium text-[#DDDDDD]')}>{description}</p>

--- a/src/entities/project/ui/ProjectRequestCard.tsx
+++ b/src/entities/project/ui/ProjectRequestCard.tsx
@@ -14,6 +14,7 @@ const ProjectRequestCard = ({ data }: ProjectRequestCardProps) => {
   const { logo, title, affiliation, createdAt, status, projectId } = data;
   const requestStatusMeta = getProjectRequestStatusMeta(status);
   const formattedDate = new Date(createdAt).toISOString().substring(0, 10);
+  const displayAffiliation = affiliation ?? '소속 정보 없음';
 
   return (
     <Link
@@ -28,7 +29,7 @@ const ProjectRequestCard = ({ data }: ProjectRequestCardProps) => {
         </div>
         <div className={cn('flex flex-col gap-y-2')}>
           <h3 className={cn('text-xl leading-6 font-semibold text-white')}>{title}</h3>
-          <p className={cn('text-sm leading-4.25 text-[#9A9A9A]')}>{affiliation}</p>
+          <p className={cn('text-sm leading-4.25 text-[#9A9A9A]')}>{displayAffiliation}</p>
         </div>
       </div>
       <div className={cn('flex items-center gap-x-4')}>

--- a/src/features/register-project/ui/RegisterProjectForm.tsx
+++ b/src/features/register-project/ui/RegisterProjectForm.tsx
@@ -148,11 +148,16 @@ const RegisterProjectForm = () => {
 
     try {
       const logoKey = await handlePhotoUpload(file);
+      const repositories = data.repository
+        .map(({ repoUrl }) => repoUrl.trim())
+        .filter((repoUrl) => repoUrl !== '');
+      const prodUrl = data.prodUrl.trim() || undefined;
 
       const requestBody: ProjectRegisterReqType = {
         ...data,
         logo: logoKey,
-        repository: data.repository.map(({ repoUrl }) => repoUrl),
+        repository: repositories.length > 0 ? repositories : undefined,
+        prodUrl,
       };
 
       postProject(requestBody);

--- a/src/features/register-project/ui/RegisterProjectForm.tsx
+++ b/src/features/register-project/ui/RegisterProjectForm.tsx
@@ -8,6 +8,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
+import { ProjectRegisterReqType } from '@/entities/project';
 import { PlusIcon, UploadIcon, XIcon } from '@/shared/assets';
 import { annotationStyle, errorTextStyle, inputTextStyle, textStyle } from '@/shared/styles';
 import { InputForm } from '@/shared/ui';
@@ -148,12 +149,13 @@ const RegisterProjectForm = () => {
     try {
       const logoKey = await handlePhotoUpload(file);
 
-      const updatedData = {
+      const requestBody: ProjectRegisterReqType = {
         ...data,
         logo: logoKey,
+        repository: data.repository.map(({ repoUrl }) => repoUrl),
       };
 
-      postProject(updatedData);
+      postProject(requestBody);
     } catch (error) {
       console.log(error);
     }

--- a/src/views/project-request-detail/ui/ProjectRequestDetailPage.tsx
+++ b/src/views/project-request-detail/ui/ProjectRequestDetailPage.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 
 import { ProjectResponseType, useGetMyProject } from '@/entities/project';
@@ -7,7 +9,7 @@ import { ProjectRequestDetailContent } from '@/widgets/project-request-detail';
 
 interface ProjectRequestDetailPageProps {
   projectId: number;
-  initialProjectData: ProjectResponseType;
+  initialProjectData: ProjectResponseType | undefined;
 }
 
 const ProjectRequestDetailPage = ({
@@ -17,7 +19,7 @@ const ProjectRequestDetailPage = ({
   const { data: myProjectData } = useGetMyProject(projectId, {
     initialData: initialProjectData,
   });
-  const project = myProjectData?.data ?? initialProjectData.data;
+  const project = myProjectData?.data ?? initialProjectData?.data;
 
   return (
     <main className={cn('min-h-[calc(100vh-72px)] bg-[#191919] p-4')}>

--- a/src/widgets/project-request-detail/ui/ProjectRequestDetailContent.tsx
+++ b/src/widgets/project-request-detail/ui/ProjectRequestDetailContent.tsx
@@ -7,13 +7,31 @@ import { ArrowIcon } from '@/shared/assets';
 import { cn } from '@/shared/utils';
 
 interface ProjectRequestDetailContentProps {
-  project: ProjectType;
+  project: ProjectType | undefined;
 }
 
 const ProjectRequestDetailContent = ({ project }: ProjectRequestDetailContentProps) => {
+  if (!project) {
+    return (
+      <div
+        className={cn(
+          'flex w-full max-w-212 flex-col items-center gap-y-4 rounded-xl bg-[rgba(34,34,34,0.50)] p-6 shadow-[inset_0_0_0_1px_#2F2F2F] backdrop-blur-[1.125rem]',
+        )}
+      >
+        <h1 className={cn('text-2xl font-semibold text-[#FF7C7C]')}>
+          프로젝트 정보를 불러올 수 없습니다.
+        </h1>
+        <p className={cn('text-sm font-medium text-[#DDDDDD]')}>
+          요청하신 프로젝트는 존재하지 않거나, 접근 권한이 없습니다.
+        </p>
+      </div>
+    );
+  }
+
   const { status, reason, logo, title, affiliation, description, techStack, repository, prodUrl } =
     project;
   const requestStatusMeta = getProjectRequestStatusMeta(status);
+  const displayAffiliation = affiliation ?? '소속 정보 없음';
 
   return (
     <>
@@ -95,7 +113,7 @@ const ProjectRequestDetailContent = ({ project }: ProjectRequestDetailContentPro
               'text-base leading-[1.2rem] font-medium tracking-[-0.03rem] text-[#FFFFFF]',
             )}
           >
-            {affiliation}
+            {displayAffiliation}
           </p>
         </div>
         <div className={cn('flex flex-col gap-y-3')}>


### PR DESCRIPTION
  ## 개요 💡

  Swagger 문서와 실제 프로젝트 API 응답을 기준으로, 프로젝트 관련 타입 선언과 상세 페이지
  처리 로직의 정합성을 맞추기 위해 수정했습니다.

  ## 작업내용 ⌨️

  - `src/entities/project/model/types.ts`의 프로젝트 응답/요청 타입을 실제 API 스펙에 맞게
  수정했습니다.
  - `getMyProject` 반환 타입을 정리하고, 프로젝트 상세 조회 시 `undefined` 응답을 안전하게
  처리하도록 보완했습니다.
  - 프로젝트 요청 상세 페이지에서 데이터가 없을 때 안내 UI가 보이도록 처리했습니다.
  - `affiliation`이 `null`인 경우를 대비해 카드/상세/요청 카드에 fallback 문구를 추가했습니
  다.
  - 프로젝트 등록 시 `repository` 값을 API 요청 형태에 맞게 변환하도록 수정했습니다.