### PR TITLE
[fix] /userinfo 엔드포인트 요청에 대한 내용 수정

### DIFF
--- a/src/shared/utils/pkce.ts
+++ b/src/shared/utils/pkce.ts
@@ -40,6 +40,7 @@ export const createAuthorizeUrl = ({
     state,
     code_challenge: codeChallenge,
     code_challenge_method: 'S256',
+    scope: 'self_read',
   });
 
   return `${authorizeBaseUrl}?${params.toString()}`;

--- a/src/shared/utils/pkce.ts
+++ b/src/shared/utils/pkce.ts
@@ -31,7 +31,7 @@ export const createAuthorizeUrl = ({
   state,
   codeChallenge,
 }: CreateAuthorizeUrlParams): string => {
-  const authorizeBaseUrl = 'https://oauth.data.hellogsm.kr/v1/oauth/authorize';
+  const authorizeBaseUrl = 'https://oauth.authorization.datagsm.kr/v1/oauth/authorize';
 
   const params = new URLSearchParams({
     client_id: clientId,


### PR DESCRIPTION
## 개요 💡

`/userinfo` 엔드포인트로 요청이 전달되지 않는 버그를 수정합니다.

datagsm-server의 도메인이 `hellogsm.kr`에서 `datagsm.kr`로 변경되었으나 Authorization URL이 구 도메인으로 하드코딩되어 있었고, PR #289(OAuth Custom Scope 지원)에 따라 `/userinfo` 접근에 `self_read` scope가 필요하게 되었으나 Authorization 요청에 scope가 포함되지 않고 있었습니다.

## 작업내용 ⌨️

`src/shared/utils/pkce.ts`

- Authorization URL 도메인 변경
  - `https://oauth.data.hellogsm.kr/v1/oauth/authorize` → `https://oauth.authorization.datagsm.kr/v1/oauth/authorize`
- Authorization 요청에 `scope: 'self_read'` 파라미터 추가
  - datagsm-server PR #289 이후 `/userinfo`는 access token에 `self_read` scope가 없으면 401 반환

## 관련 이슈 🚨

- datagsm-server PR #289 (OAuth Custom Scope 지원)
- datagsm-server PR #315 (OAuth SpEL 파싱 버그 픽스)