### PR TITLE
[style] 자잘한 UI 표시 개선

### DIFF
--- a/src/entities/project/ui/ProjectCard.tsx
+++ b/src/entities/project/ui/ProjectCard.tsx
@@ -44,10 +44,13 @@ const ProjectCard = ({ data, likeButton, onDetailClick }: ProjectCardProps) => {
       const gap = Number.parseFloat(window.getComputedStyle(listElement).columnGap);
       const gapWidth = Number.isNaN(gap) ? 0 : gap;
       const techStackWidths = techStackElements.map((element) => element.offsetWidth);
-      const widthSums = techStackWidths.reduce<number[]>(
-        (sums, width) => [...sums, sums[sums.length - 1] + width],
-        [0],
-      );
+      const widthSums = [0];
+      let currentWidthSum = 0;
+
+      for (const width of techStackWidths) {
+        currentWidthSum += width;
+        widthSums.push(currentWidthSum);
+      }
 
       for (let count = techStackElements.length; count >= 0; count -= 1) {
         const hiddenCount = techStackElements.length - count;

--- a/src/entities/project/ui/ProjectCard.tsx
+++ b/src/entities/project/ui/ProjectCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 import Image from 'next/image';
 
@@ -14,12 +14,66 @@ interface ProjectCardProps {
   onDetailClick?: () => void;
 }
 
+const techStackPillClassName =
+  'rounded-full bg-[#4F4F4F] px-2 py-1.5 text-xs leading-[.9rem] font-medium whitespace-nowrap text-white';
+
 const ProjectCard = ({ data, likeButton, onDetailClick }: ProjectCardProps) => {
   const { logo, title, affiliation, description, techStack, prodUrl } = data;
   const hasLogo = Boolean(logo?.trim());
   const displayAffiliation = affiliation ?? '소속 정보 없음';
-
   const [isCenterHover, setIsCenterHover] = useState(false);
+  const [visibleTechStackCount, setVisibleTechStackCount] = useState(techStack.length);
+  const techStackListRef = useRef<HTMLDivElement>(null);
+  const techStackMeasureRef = useRef<HTMLDivElement>(null);
+  const moreTechStackMeasureRef = useRef<HTMLSpanElement>(null);
+  const visibleTechStack = techStack.slice(0, visibleTechStackCount);
+  const hiddenTechStackCount = techStack.length - visibleTechStack.length;
+
+  useLayoutEffect(() => {
+    const listElement = techStackListRef.current;
+    const measureElement = techStackMeasureRef.current;
+    const moreMeasureElement = moreTechStackMeasureRef.current;
+
+    if (!listElement || !measureElement || !moreMeasureElement) return;
+
+    const measureVisibleTechStackCount = () => {
+      const availableWidth = listElement.clientWidth;
+      const techStackElements = Array.from(
+        measureElement.querySelectorAll<HTMLElement>('[data-tech-stack-item]'),
+      );
+      const gap = Number.parseFloat(window.getComputedStyle(listElement).columnGap);
+      const gapWidth = Number.isNaN(gap) ? 0 : gap;
+      const techStackWidths = techStackElements.map((element) => element.offsetWidth);
+      const widthSums = techStackWidths.reduce<number[]>(
+        (sums, width) => [...sums, sums[sums.length - 1] + width],
+        [0],
+      );
+
+      for (let count = techStackElements.length; count >= 0; count -= 1) {
+        const hiddenCount = techStackElements.length - count;
+        moreMeasureElement.textContent = `+${hiddenCount}`;
+
+        const moreWidth = hiddenCount > 0 ? moreMeasureElement.offsetWidth : 0;
+        const renderedItemCount = count + (hiddenCount > 0 ? 1 : 0);
+        const totalGapWidth = Math.max(renderedItemCount - 1, 0) * gapWidth;
+        const totalWidth = widthSums[count] + moreWidth + totalGapWidth;
+
+        if (totalWidth <= availableWidth) {
+          setVisibleTechStackCount(count);
+          return;
+        }
+      }
+
+      setVisibleTechStackCount(0);
+    };
+
+    measureVisibleTechStackCount();
+
+    const resizeObserver = new ResizeObserver(measureVisibleTechStackCount);
+    resizeObserver.observe(listElement);
+
+    return () => resizeObserver.disconnect();
+  }, [techStack]);
 
   return (
     <div
@@ -80,17 +134,36 @@ const ProjectCard = ({ data, likeButton, onDetailClick }: ProjectCardProps) => {
           <div className={cn('line-clamp-2 h-9 text-xs leading-4.5 font-medium text-[#9A9A9A]')}>
             {description}
           </div>
-          <div className={cn('flex h-6.5 flex-wrap gap-x-1.5 overflow-hidden')}>
-            {techStack.map((stack) => (
-              <span
-                key={stack.stackName}
-                className={cn(
-                  'rounded-full bg-[#4F4F4F] px-2 py-1.5 text-xs leading-[.9rem] font-medium text-white',
-                )}
-              >
+          <div
+            ref={techStackListRef}
+            className={cn('relative flex flex-wrap gap-x-1.5 overflow-hidden')}
+          >
+            {visibleTechStack.map((stack, index) => (
+              <span key={`${stack.stackName}-${index}`} className={cn(techStackPillClassName)}>
                 {stack.stackName}
               </span>
             ))}
+            {hiddenTechStackCount > 0 && (
+              <span className={cn(techStackPillClassName)}>+{hiddenTechStackCount}</span>
+            )}
+            <div
+              ref={techStackMeasureRef}
+              aria-hidden
+              className={cn(
+                'pointer-events-none absolute top-0 left-0 flex gap-x-1.5 overflow-hidden opacity-0',
+              )}
+            >
+              {techStack.map((stack, index) => (
+                <span
+                  key={`${stack.stackName}-${index}`}
+                  data-tech-stack-item
+                  className={cn(techStackPillClassName)}
+                >
+                  {stack.stackName}
+                </span>
+              ))}
+              <span ref={moreTechStackMeasureRef} className={cn(techStackPillClassName)} />
+            </div>
           </div>
         </div>
       </div>

--- a/src/entities/project/ui/ProjectCard.tsx
+++ b/src/entities/project/ui/ProjectCard.tsx
@@ -14,15 +14,16 @@ interface ProjectCardProps {
   onDetailClick?: () => void;
 }
 
-const techStackPillClassName =
-  'rounded-full bg-[#4F4F4F] px-2 py-1.5 text-xs leading-[.9rem] font-medium whitespace-nowrap text-white';
+const techStackPillClassName = cn(
+  'rounded-full bg-[#4F4F4F] px-2 py-1.5 text-xs leading-[.9rem] font-medium whitespace-nowrap text-white',
+);
 
 const ProjectCard = ({ data, likeButton, onDetailClick }: ProjectCardProps) => {
   const { logo, title, affiliation, description, techStack, prodUrl } = data;
   const hasLogo = Boolean(logo?.trim());
   const displayAffiliation = affiliation ?? '소속 정보 없음';
-  const [isCenterHover, setIsCenterHover] = useState(false);
-  const [visibleTechStackCount, setVisibleTechStackCount] = useState(techStack.length);
+  const [isCenterHover, setIsCenterHover] = useState<boolean>(false);
+  const [visibleTechStackCount, setVisibleTechStackCount] = useState<number>(techStack.length);
   const techStackListRef = useRef<HTMLDivElement>(null);
   const techStackMeasureRef = useRef<HTMLDivElement>(null);
   const moreTechStackMeasureRef = useRef<HTMLSpanElement>(null);

--- a/src/features/register-project/model/constants.ts
+++ b/src/features/register-project/model/constants.ts
@@ -1,25 +1,45 @@
 export const DEFAULT_TECH_STACKS = [
+  // Language
   'HTML5',
   'CSS3',
   'JavaScript',
   'TypeScript',
+  'Java',
+  'Kotlin',
+  'Python',
+
+  // Frontend
   'React',
   'Next.js',
   'Tailwind CSS',
+
+  // Backend
   'Node.js',
   'Express',
   'NestJS',
   'Spring Boot',
-  'Python',
+  'Django',
+  'Flask',
+  'FastAPI',
+
+  // Database
   'MySQL',
   'PostgreSQL',
   'MongoDB',
   'Redis',
+
+  // Infra / Deployment
   'AWS',
   'Vercel',
   'Docker',
   'Nginx',
-  'GitHub Actions',
+
+  // BaaS
   'Firebase',
   'Supabase',
+
+  // AI
+  'PyTorch',
+  'TensorFlow',
+  'LangChain',
 ] as const;

--- a/src/features/register-project/ui/RepositoryUrlField.tsx
+++ b/src/features/register-project/ui/RepositoryUrlField.tsx
@@ -36,7 +36,10 @@ const RepositoryUrlField = ({
 
       <div className={cn('flex flex-col gap-3')}>
         {repositoryUrls.map((repositoryUrl, index) => (
-          <div key={index} className={cn('flex w-full items-center p-4', fieldShellClassName)}>
+          <div
+            key={index}
+            className={cn('flex w-full items-center overflow-hidden', fieldShellClassName)}
+          >
             <input
               name="repositoryUrls"
               type="text"
@@ -44,12 +47,12 @@ const RepositoryUrlField = ({
               value={repositoryUrl}
               placeholder="깃허브 레포지토리 URL을 입력해주세요"
               onChange={(event) => onUpdateRepositoryUrl(index, event.target.value)}
-              className={cn('w-full', inputTextClassName, placeholderClassName)}
+              className={cn('w-full p-4', inputTextClassName, placeholderClassName)}
             />
             <button
               type="button"
               onClick={() => onRemoveRepositoryInput(index)}
-              className={cn('flex cursor-pointer items-center justify-center')}
+              className={cn('flex cursor-pointer items-center justify-center p-4')}
               aria-label="깃허브 레포지토리 삭제"
             >
               <XIcon />

--- a/src/features/register-project/ui/TechStackField.tsx
+++ b/src/features/register-project/ui/TechStackField.tsx
@@ -53,7 +53,7 @@ const TechStackField = ({
                 type="button"
                 onClick={() => onToggleTechStack(stack)}
                 className={cn(
-                  'rounded-full px-4 py-2 text-base leading-[1.2rem] font-medium tracking-[-0.03rem] text-[#DDD] transition-colors',
+                  'cursor-pointer rounded-full px-4 py-2 text-base leading-[1.2rem] font-medium tracking-[-0.03rem] text-[#DDD] transition-colors',
                   isSelected ? 'bg-[#FC335A] text-white' : 'bg-[#4F4F4F]',
                 )}
               >
@@ -87,7 +87,7 @@ const TechStackField = ({
           <p className={cn(hintClassName)}>최대 50개 추가 입력</p>
         </div>
 
-        <div className={cn('flex w-full items-center p-4', fieldShellClassName)}>
+        <div className={cn('flex w-full items-center overflow-hidden', fieldShellClassName)}>
           <input
             id="project-tech-stack"
             name="techStack"
@@ -96,13 +96,13 @@ const TechStackField = ({
             placeholder="위의 기술 스택 이외에 추가할 기술스택이 있다면 입력해주세요"
             onChange={onTechStackInputChange}
             onKeyDown={onTechStackInputKeyDown}
-            className={cn('w-full', inputTextClassName, placeholderClassName)}
+            className={cn('w-full p-4', inputTextClassName, placeholderClassName)}
           />
           {hasTechStackInput && (
             <button
               type="button"
               onClick={onAddCustomTechStack}
-              className={cn('flex cursor-pointer items-center justify-center')}
+              className={cn('flex cursor-pointer items-center justify-center p-4')}
               aria-label="기술 스택 추가"
             >
               <ArrowIcon />


### PR DESCRIPTION
## 개요 💡

프로젝트 카드와 프로젝트 등록 폼의 UI 표시를 일부 개선했습니다.

## 작업내용 ⌨️

- 프로젝트 카드의 기술스택이 카드 영역을 넘치지 않도록 표시 로직을 개선했습니다.
- 렌더링 가능한 기술스택만 노출하고, 숨겨진 항목은 `+N` 형태로 표시되도록 수정했습니다.
- 프로젝트 등록 폼의 기술스택/레포지토리 입력 UI 여백과 overflow 처리를 정리했습니다.
- 기본 기술스택 목록을 보강했습니다.

## 스크린샷/동영상 📸

<img width="1512" height="982" alt="스크린샷 2026-04-29 오후 4 57 42" src="https://github.com/user-attachments/assets/bb3fe684-f0cb-47ef-b6fd-001e12beba32" />
<img width="1512" height="982" alt="스크린샷 2026-04-29 오후 4 58 07" src="https://github.com/user-attachments/assets/86bc2b89-66bc-4d1b-abac-4e2854507b51" />
<img width="1512" height="982" alt="스크린샷 2026-04-29 오후 4 58 35" src="https://github.com/user-attachments/assets/daa48392-e67e-4a43-bb74-5ecaee05c161" />