### PR TITLE
[feat] 프로젝트 삭제 기능 작업

### DIFF
--- a/src/entities/project/index.ts
+++ b/src/entities/project/index.ts
@@ -2,6 +2,7 @@ export * from './model/requestStatus';
 export * from './model/types';
 export * from './model/useAdminApproveProject';
 export * from './model/useAdminRejectProject';
+export * from './model/useDeleteMyProject';
 export * from './model/useGetAdminRequest';
 export * from './model/useGetMyPendingProjects';
 export * from './model/useGetMyProject';

--- a/src/entities/project/model/useDeleteMyProject.ts
+++ b/src/entities/project/model/useDeleteMyProject.ts
@@ -9,6 +9,7 @@ export const useDeleteMyProject = () => {
     mutationFn: (projectId: number) => del(projectUrl.deleteMyProject(projectId)),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyProjects() });
+      queryClient.invalidateQueries({ queryKey: projectQueryKeys.getProjects() });
     },
   });
 };

--- a/src/entities/project/model/useDeleteMyProject.ts
+++ b/src/entities/project/model/useDeleteMyProject.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { del, projectQueryKeys, projectUrl } from '@/shared/api';
+
+export const useDeleteMyProject = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (projectId: number) => del(projectUrl.deleteMyProject(projectId)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyProjects() });
+    },
+  });
+};

--- a/src/features/delete-project/index.ts
+++ b/src/features/delete-project/index.ts
@@ -1,0 +1,1 @@
+export { default as ProjectActionMenu } from './ui/ProjectActionMenu';

--- a/src/features/delete-project/ui/DeleteConfirmModal.tsx
+++ b/src/features/delete-project/ui/DeleteConfirmModal.tsx
@@ -44,8 +44,9 @@ const DeleteConfirmModal = ({ projectId }: DeleteConfirmModalProps) => {
       <div className={cn('flex w-full items-center justify-between')}>
         <button
           onClick={closeModal}
+          disabled={isPending}
           className={cn(
-            'flex cursor-pointer items-center justify-center gap-28 rounded-xl border border-[#FC335A] px-9 py-3 text-[1.125rem] font-medium text-[#FC335A]',
+            'flex cursor-pointer items-center justify-center rounded-xl border border-[#FC335A] px-9 py-3 text-[1.125rem] font-medium text-[#FC335A] disabled:opacity-50',
           )}
         >
           취소
@@ -54,7 +55,7 @@ const DeleteConfirmModal = ({ projectId }: DeleteConfirmModalProps) => {
           onClick={handleConfirm}
           disabled={isPending}
           className={cn(
-            'flex cursor-pointer items-center justify-center gap-28 rounded-xl bg-[#FC335A] px-9 py-3 text-[1.125rem] font-medium text-white disabled:opacity-50',
+            'flex cursor-pointer items-center justify-center rounded-xl bg-[#FC335A] px-9 py-3 text-[1.125rem] font-medium text-white disabled:opacity-50',
           )}
         >
           확인

--- a/src/features/delete-project/ui/DeleteConfirmModal.tsx
+++ b/src/features/delete-project/ui/DeleteConfirmModal.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { toast } from 'sonner';
+
+import { useDeleteMyProject } from '@/entities/project';
+import { useModalStore } from '@/shared/stores';
+import { cn } from '@/shared/utils';
+
+interface DeleteConfirmModalProps {
+  projectId: number;
+}
+
+const DeleteConfirmModal = ({ projectId }: DeleteConfirmModalProps) => {
+  const { closeModal } = useModalStore();
+  const { mutate: deleteProject, isPending } = useDeleteMyProject();
+
+  const handleConfirm = () => {
+    deleteProject(projectId, {
+      onSuccess: () => {
+        closeModal();
+        toast.success('프로젝트가 삭제되었습니다.');
+      },
+      onError: () => {
+        toast.error('프로젝트 삭제에 실패했습니다.');
+      },
+    });
+  };
+
+  return (
+    <div
+      className={cn(
+        'flex w-120 flex-col items-start gap-6 rounded-xl border border-[#2F2F2F] bg-[rgba(34,34,34,0.50)] p-6 backdrop-blur-[18px]',
+      )}
+    >
+      <h2 className={cn('w-full text-center text-[1.25rem] font-semibold text-white')}>
+        프로젝트 삭제
+      </h2>
+      <p className={cn('w-full text-center text-[1rem] leading-6 font-medium text-white')}>
+        프로젝트를 정말 삭제하시겠습니까? 삭제된 프로젝트는
+        <br />
+        다시 복구할 수 없습니다.
+      </p>
+
+      <div className={cn('flex w-full items-center justify-between')}>
+        <button
+          onClick={closeModal}
+          className={cn(
+            'flex cursor-pointer items-center justify-center gap-28 rounded-xl border border-[#FC335A] px-9 py-3 text-[1.125rem] font-medium text-[#FC335A]',
+          )}
+        >
+          취소
+        </button>
+        <button
+          onClick={handleConfirm}
+          disabled={isPending}
+          className={cn(
+            'flex cursor-pointer items-center justify-center gap-28 rounded-xl bg-[#FC335A] px-9 py-3 text-[1.125rem] font-medium text-white disabled:opacity-50',
+          )}
+        >
+          확인
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DeleteConfirmModal;

--- a/src/features/delete-project/ui/ProjectActionMenu.tsx
+++ b/src/features/delete-project/ui/ProjectActionMenu.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { ArrowIcon, HamburgerIcon } from '@/shared/assets';
+import { useOnClickOutside } from '@/shared/hooks';
 import { useModalStore } from '@/shared/stores';
 import { cn } from '@/shared/utils';
 
@@ -17,15 +18,7 @@ const ProjectActionMenu = ({ projectId }: ProjectActionMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
   const { openModal } = useModalStore();
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  useOnClickOutside(menuRef as React.RefObject<HTMLElement>, () => setIsOpen(false));
 
   const handleDelete = () => {
     setIsOpen(false);

--- a/src/features/delete-project/ui/ProjectActionMenu.tsx
+++ b/src/features/delete-project/ui/ProjectActionMenu.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { ArrowIcon, HamburgerIcon } from '@/shared/assets';
+import { useModalStore } from '@/shared/stores';
+import { cn } from '@/shared/utils';
+
+import DeleteConfirmModal from './DeleteConfirmModal';
+
+interface ProjectActionMenuProps {
+  projectId: number;
+}
+
+const ProjectActionMenu = ({ projectId }: ProjectActionMenuProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const { openModal } = useModalStore();
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleDelete = () => {
+    setIsOpen(false);
+    openModal(<DeleteConfirmModal projectId={projectId} />);
+  };
+
+  return (
+    <div ref={menuRef} className={cn('relative')}>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          setIsOpen((prev) => !prev);
+        }}
+        className={cn('cursor-pointer')}
+        aria-label="프로젝트 메뉴 열기"
+      >
+        <HamburgerIcon />
+      </button>
+
+      {isOpen && (
+        <div
+          className={cn(
+            'absolute top-8 right-0 z-50 inline-flex flex-col items-end justify-center gap-2 rounded-xl border border-[#2F2F2F] bg-[rgba(34,34,34,0.50)] p-3 backdrop-blur-[18px]',
+          )}
+        >
+          <button
+            className={cn(
+              'flex cursor-pointer items-center gap-4 py-1.5 text-base leading-6 font-medium whitespace-nowrap text-white',
+            )}
+          >
+            프로젝트 수정하기
+            <ArrowIcon />
+          </button>
+          <button
+            onClick={handleDelete}
+            className={cn(
+              'flex cursor-pointer items-center gap-4 py-1.5 text-base leading-6 font-medium whitespace-nowrap text-white',
+            )}
+          >
+            프로젝트 삭제
+            <ArrowIcon />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProjectActionMenu;

--- a/src/features/delete-project/ui/ProjectActionMenu.tsx
+++ b/src/features/delete-project/ui/ProjectActionMenu.tsx
@@ -35,8 +35,7 @@ const ProjectActionMenu = ({ projectId }: ProjectActionMenuProps) => {
   return (
     <div ref={menuRef} className={cn('relative')}>
       <button
-        onClick={(e) => {
-          e.stopPropagation();
+        onClick={() => {
           setIsOpen((prev) => !prev);
         }}
         className={cn('cursor-pointer')}

--- a/src/shared/api/apiUrls.ts
+++ b/src/shared/api/apiUrls.ts
@@ -15,6 +15,7 @@ export const userUrl = {
 } as const;
 
 export const projectUrl = {
+  deleteMyProject: (projectId: number) => `/api/v2/projects/my/${projectId}`,
   deleteProjectLike: (projectId: number) => `/api/v2/projects/like/${projectId}`,
   getProjects: () => '/api/v2/projects',
   getMyProjects: () => '/api/v2/projects/my',

--- a/src/shared/api/queryKeys.ts
+++ b/src/shared/api/queryKeys.ts
@@ -14,6 +14,7 @@ export const projectQueryKeys = {
   getMyRejectedProjects: () => ['projects', 'my', 'rejected'] as const,
   getMyPendingProjects: () => ['projects', 'my', 'pending'] as const,
   postProjectRegistration: () => ['projects', 'create'] as const,
+  deleteMyProject: (projectId: number) => ['projects', 'my', 'delete', projectId] as const,
   toggleProjectLike: (projectId: number) => ['projects', 'like', 'toggle', projectId] as const,
 } as const;
 

--- a/src/shared/assets/HamburgerIcon.tsx
+++ b/src/shared/assets/HamburgerIcon.tsx
@@ -1,0 +1,27 @@
+const HamburgerIcon = () => (
+  <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M22 6H6"
+      stroke="#888888"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M22 14H6"
+      stroke="#888888"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M22 22H6"
+      stroke="#888888"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default HamburgerIcon;

--- a/src/shared/assets/index.ts
+++ b/src/shared/assets/index.ts
@@ -1,5 +1,6 @@
 export { default as ArrowIcon } from './ArrowIcon';
 export { default as CloseIcon } from './CloseIcon';
+export { default as HamburgerIcon } from './HamburgerIcon';
 export { default as LikeIcon } from './LikeIcon';
 export { default as Logo } from './Logo';
 export { default as PersonIcon } from './PersonIcon';

--- a/src/views/mypage/ui/MyPage.tsx
+++ b/src/views/mypage/ui/MyPage.tsx
@@ -10,6 +10,7 @@ import {
   useGetMyRejectedProjects,
 } from '@/entities/project';
 import { useGetMyInfo, UserInfoResponseType } from '@/entities/user';
+import { ProjectActionMenu } from '@/features/delete-project';
 import { RequestStatusFilter, RequestStatusFilterType } from '@/features/request-status-filter';
 import { useHandleErrorQueryToast } from '@/shared/hooks';
 import { cn } from '@/shared/utils';
@@ -84,7 +85,10 @@ const MyPage = ({
               </>
             }
           />
-          <ProjectList projects={registeredProjects} />
+          <ProjectList
+            projects={registeredProjects}
+            renderActionButton={(project) => <ProjectActionMenu projectId={project.projectId} />}
+          />
         </div>
 
         <div className={cn('flex flex-col items-center gap-y-10')}>

--- a/src/widgets/project-list/ui/ProjectList.tsx
+++ b/src/widgets/project-list/ui/ProjectList.tsx
@@ -11,9 +11,14 @@ import { cn } from '@/shared/utils';
 interface ProjectListProps {
   projects: ProjectType[];
   showRegisterCard?: boolean;
+  renderActionButton?: (project: ProjectType) => React.ReactNode;
 }
 
-const ProjectList = ({ projects, showRegisterCard = false }: ProjectListProps) => {
+const ProjectList = ({
+  projects,
+  showRegisterCard = false,
+  renderActionButton,
+}: ProjectListProps) => {
   const { openModal } = useModalStore();
 
   return (
@@ -40,7 +45,13 @@ const ProjectList = ({ projects, showRegisterCard = false }: ProjectListProps) =
         <ProjectCard
           key={project.projectId}
           data={project}
-          likeButton={<LikeButton isLiked={project.liked} projectId={project.projectId} />}
+          likeButton={
+            renderActionButton ? (
+              renderActionButton(project)
+            ) : (
+              <LikeButton isLiked={project.liked} projectId={project.projectId} />
+            )
+          }
           onDetailClick={() =>
             openModal(
               <ProjectDetailModal


### PR DESCRIPTION
## 개요 💡

마이페이지에서 등록한 프로젝트를 삭제할 수 있는 기능을 추가했습니다.

## 작업내용 ⌨️

- `useDeleteMyProject` 훅 및 삭제 API URL, 쿼리 키 추가
- `ProjectActionMenu` 컴포넌트 추가 (수정/삭제 드롭다운 메뉴)
- `DeleteConfirmModal` 컴포넌트 추가 (삭제 확인 모달)
- 삭제 성공 시 `프로젝트가 삭제되었습니다.`, 실패 시 `프로젝트 삭제에 실패했습니다.` 토스트 표시
- `ProjectList`에 `renderActionButton` prop 추가하여 액션 버튼 커스터마이징 가능하도록 변경
- `HamburgerIcon` 아이콘 추가


## 스크린샷/동영상 📸

https://github.com/user-attachments/assets/887b817a-928f-4c65-8cab-1e0e66813f2e


현재 mock 데이터로 진행하여 프로젝트 삭제 성공 시연을 보여드리지 못한 점 양해 부탁드립니다.

## 관련 이슈 🚨

https://github.com/themoment-team/EveryGSM-client-v2/issues/56

