### PR TITLE
[shared/api] mutation 훅 및 쿼리 키 정리

### DIFF
--- a/src/entities/project/model/useAdminApproveProject.ts
+++ b/src/entities/project/model/useAdminApproveProject.ts
@@ -11,7 +11,7 @@ export const useAdminApproveProject = () => {
     mutationFn: (projectId: number) =>
       patch<ProjectResponseType>(adminUrl.patchAdminApproveProject(projectId)),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: adminQueryKeys.all() });
+      await queryClient.invalidateQueries({ queryKey: adminQueryKeys.getAdminRequests() });
     },
   });
 };

--- a/src/entities/project/model/useAdminApproveProject.ts
+++ b/src/entities/project/model/useAdminApproveProject.ts
@@ -1,11 +1,17 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { adminUrl, patch } from '@/shared/api';
+import { adminQueryKeys, adminUrl, patch } from '@/shared/api';
 
 import { ProjectResponseType } from './types';
 
-export const useAdminApproveProject = () =>
-  useMutation({
+export const useAdminApproveProject = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
     mutationFn: (projectId: number) =>
       patch<ProjectResponseType>(adminUrl.patchAdminApproveProject(projectId)),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: adminQueryKeys.all() });
+    },
   });
+};

--- a/src/entities/project/model/useAdminRejectProject.ts
+++ b/src/entities/project/model/useAdminRejectProject.ts
@@ -11,7 +11,7 @@ export const useAdminRejectProject = () => {
     mutationFn: ({ projectId, reason }: { projectId: number; reason: string }) =>
       patch<ProjectResponseType>(adminUrl.patchAdminRejectProject(projectId), { reason }),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: adminQueryKeys.all() });
+      await queryClient.invalidateQueries({ queryKey: adminQueryKeys.getAdminRequests() });
     },
   });
 };

--- a/src/entities/project/model/useAdminRejectProject.ts
+++ b/src/entities/project/model/useAdminRejectProject.ts
@@ -1,11 +1,17 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { adminUrl, patch } from '@/shared/api';
+import { adminQueryKeys, adminUrl, patch } from '@/shared/api';
 
 import { ProjectResponseType } from './types';
 
-export const useAdminRejectProject = () =>
-  useMutation({
+export const useAdminRejectProject = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
     mutationFn: ({ projectId, reason }: { projectId: number; reason: string }) =>
       patch<ProjectResponseType>(adminUrl.patchAdminRejectProject(projectId), { reason }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: adminQueryKeys.all() });
+    },
   });
+};

--- a/src/entities/project/model/useDeleteMyProject.ts
+++ b/src/entities/project/model/useDeleteMyProject.ts
@@ -10,6 +10,8 @@ export const useDeleteMyProject = () => {
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyProjects() }),
+        queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyPendingProjects() }),
+        queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyRejectedProjects() }),
         queryClient.invalidateQueries({ queryKey: projectQueryKeys.getProjects() }),
       ]);
     },

--- a/src/entities/project/model/useDeleteMyProject.ts
+++ b/src/entities/project/model/useDeleteMyProject.ts
@@ -7,9 +7,11 @@ export const useDeleteMyProject = () => {
 
   return useMutation({
     mutationFn: (projectId: number) => del(projectUrl.deleteMyProject(projectId)),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyProjects() });
-      queryClient.invalidateQueries({ queryKey: projectQueryKeys.getProjects() });
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyProjects() }),
+        queryClient.invalidateQueries({ queryKey: projectQueryKeys.getProjects() }),
+      ]);
     },
   });
 };

--- a/src/features/edit-project/model/usePatchMyProject.ts
+++ b/src/features/edit-project/model/usePatchMyProject.ts
@@ -7,7 +7,6 @@ export const usePatchMyProject = (projectId: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationKey: projectQueryKeys.patchMyProject(projectId),
     mutationFn: (body: ProjectFormReqType) => patch(projectUrl.patchMyProject(projectId), body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyProjects() });

--- a/src/features/edit-project/model/usePatchMyProject.ts
+++ b/src/features/edit-project/model/usePatchMyProject.ts
@@ -8,10 +8,12 @@ export const usePatchMyProject = (projectId: number) => {
 
   return useMutation({
     mutationFn: (body: ProjectFormReqType) => patch(projectUrl.patchMyProject(projectId), body),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyProjects() });
-      queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyPendingProjects() });
-      queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyProject(projectId) });
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyProjects() }),
+        queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyPendingProjects() }),
+        queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyProject(projectId) }),
+      ]);
     },
   });
 };

--- a/src/features/like-project/model/useToggleProjectLike.ts
+++ b/src/features/like-project/model/useToggleProjectLike.ts
@@ -2,17 +2,13 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import { ProjectResponseType } from '@/entities/project';
-import { del, post, projectQueryKeys, projectUrl } from '@/shared/api';
+import { del, post, projectUrl } from '@/shared/api';
 
 export const useToggleProjectLike = (
   projectId: number,
-  options?: Omit<
-    UseMutationOptions<ProjectResponseType, AxiosError, boolean>,
-    'mutationKey' | 'mutationFn'
-  >,
+  options?: Omit<UseMutationOptions<ProjectResponseType, AxiosError, boolean>, 'mutationFn'>,
 ) =>
   useMutation({
-    mutationKey: projectQueryKeys.toggleProjectLike(projectId),
     mutationFn: (isLiked: boolean) =>
       isLiked
         ? del<ProjectResponseType>(projectUrl.deleteProjectLike(projectId))

--- a/src/features/oauth-sign-in/model/usePostOAuthSignIn.ts
+++ b/src/features/oauth-sign-in/model/usePostOAuthSignIn.ts
@@ -1,18 +1,17 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
-import { authQueryKeys, authUrl, post } from '@/shared/api';
+import { authUrl, post } from '@/shared/api';
 
 import { OAuthSignInReqType, OAuthSignInResponseType } from './types';
 
 export const usePostOAuthSignIn = (
   options?: Omit<
     UseMutationOptions<OAuthSignInResponseType, AxiosError, OAuthSignInReqType>,
-    'mutationKey' | 'mutationFn'
+    'mutationFn'
   >,
 ) =>
   useMutation({
-    mutationKey: authQueryKeys.postSignIn(),
     mutationFn: (requestBody: OAuthSignInReqType) =>
       post<OAuthSignInResponseType>(authUrl.postSignIn(), requestBody),
     ...options,

--- a/src/features/project-form/model/usePostImageUpload.ts
+++ b/src/features/project-form/model/usePostImageUpload.ts
@@ -1,18 +1,17 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
-import { imageQueryKeys, imageUrl, post } from '@/shared/api';
+import { imageUrl, post } from '@/shared/api';
 
 import { ImageUploadReqType, ImageUploadResponseType } from './types';
 
 export const usePostImageUpload = (
   options?: Omit<
     UseMutationOptions<ImageUploadResponseType, AxiosError, ImageUploadReqType>,
-    'mutationKey' | 'mutationFn'
+    'mutationFn'
   >,
 ) =>
   useMutation({
-    mutationKey: imageQueryKeys.postImageUpload(),
     mutationFn: ({ image }: ImageUploadReqType) => {
       const formData = new FormData();
       formData.append('image', image);

--- a/src/features/project-form/model/usePostProjectRegistration.ts
+++ b/src/features/project-form/model/usePostProjectRegistration.ts
@@ -8,13 +8,12 @@ import { ProjectRegistrationReqType, ProjectRegistrationResponseType } from './t
 export const usePostProjectRegistration = (
   options?: Omit<
     UseMutationOptions<ProjectRegistrationResponseType, AxiosError, ProjectRegistrationReqType>,
-    'mutationKey' | 'mutationFn'
+    'mutationFn'
   >,
 ) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationKey: projectQueryKeys.postProjectRegistration(),
     mutationFn: (requestBody: ProjectRegistrationReqType) =>
       post<ProjectRegistrationResponseType>(projectUrl.postProjectRegistration(), requestBody),
     ...options,

--- a/src/shared/api/apiUrls.ts
+++ b/src/shared/api/apiUrls.ts
@@ -15,9 +15,6 @@ export const userUrl = {
 } as const;
 
 export const projectUrl = {
-  deleteMyProject: (projectId: number) => `/api/v2/projects/my/${projectId}`,
-  patchMyProject: (projectId: number) => `/api/v2/projects/my/${projectId}`,
-  deleteProjectLike: (projectId: number) => `/api/v2/projects/like/${projectId}`,
   getProjects: () => '/api/v2/projects',
   getMyProjects: () => '/api/v2/projects/my',
   getMyProject: (id?: number) => `/api/v2/projects/my/${id}`,
@@ -25,6 +22,10 @@ export const projectUrl = {
   getMyPendingProjects: () => '/api/v2/projects/my/pending',
   postProjectRegistration: () => '/api/v2/projects/registration',
   postProjectLike: (projectId: number) => `/api/v2/projects/like/${projectId}`,
+  patchMyProject: (projectId: number) => `/api/v2/projects/my/${projectId}`,
+  patchProjectParticipants: (projectId: number) => `/api/v2/projects/${projectId}/participants`,
+  deleteMyProject: (projectId: number) => `/api/v2/projects/my/${projectId}`,
+  deleteProjectLike: (projectId: number) => `/api/v2/projects/like/${projectId}`,
 } as const;
 
 export const imageUrl = {

--- a/src/shared/api/queryKeys.ts
+++ b/src/shared/api/queryKeys.ts
@@ -1,9 +1,7 @@
 export const adminQueryKeys = {
   all: () => ['admin'] as const,
-  getAdminRequest: (requestId?: number) => ['admin', 'request', 'detail', requestId] as const,
   getAdminRequests: () => ['admin', 'requests', 'list'] as const,
-  patchAdminRejectProject: (projectId: number) => ['admin', 'reject', projectId] as const,
-  patchAdminApproveProject: (projectId: number) => ['admin', 'approve', projectId] as const,
+  getAdminRequest: (requestId?: number) => ['admin', 'request', 'detail', requestId] as const,
 } as const;
 
 export const projectQueryKeys = {
@@ -13,23 +11,10 @@ export const projectQueryKeys = {
   getMyProject: (projectId?: number) => ['projects', 'my', 'detail', projectId] as const,
   getMyRejectedProjects: () => ['projects', 'my', 'rejected'] as const,
   getMyPendingProjects: () => ['projects', 'my', 'pending'] as const,
-  postProjectRegistration: () => ['projects', 'create'] as const,
-  deleteMyProject: (projectId: number) => ['projects', 'my', 'delete', projectId] as const,
-  patchMyProject: (projectId: number) => ['projects', 'my', 'patch', projectId] as const,
-  toggleProjectLike: (projectId: number) => ['projects', 'like', 'toggle', projectId] as const,
-} as const;
-
-export const authQueryKeys = {
-  all: () => ['auth'] as const,
-  postSignIn: () => ['auth', 'signin'] as const,
 } as const;
 
 export const userQueryKeys = {
   all: () => ['users'] as const,
   getMyInfo: () => ['users', 'userinfo'] as const,
   getUsersSearch: (name: string) => ['users', 'search', name] as const,
-} as const;
-
-export const imageQueryKeys = {
-  postImageUpload: () => ['post', 'image'] as const,
 } as const;

--- a/src/views/admin/ui/AdminRequestDetailPage.tsx
+++ b/src/views/admin/ui/AdminRequestDetailPage.tsx
@@ -34,8 +34,8 @@ const AdminRequestDetailPage = ({
   });
   const project = adminRequestData?.data ?? initialRequestedProjectData?.data;
 
-  const approveMutation = useAdminApproveProject();
-  const rejectMutation = useAdminRejectProject();
+  const { mutateAsync: approveProject, isPending: isApprovePending } = useAdminApproveProject();
+  const { mutateAsync: rejectProject, isPending: isRejectPending } = useAdminRejectProject();
 
   if (!project) {
     return (
@@ -47,7 +47,7 @@ const AdminRequestDetailPage = ({
 
   const handleApprove = async () => {
     try {
-      await approveMutation.mutateAsync(project.projectId);
+      await approveProject(project.projectId);
       router.push('/admin');
     } catch (error) {
       console.error('Failed to approve project:', error);
@@ -59,7 +59,7 @@ const AdminRequestDetailPage = ({
     if (!rejectReason.trim()) return;
 
     try {
-      await rejectMutation.mutateAsync({
+      await rejectProject({
         projectId: project.projectId,
         reason: rejectReason,
       });
@@ -70,7 +70,7 @@ const AdminRequestDetailPage = ({
     }
   };
 
-  const isRejectDisabled = rejectMutation.isPending || !rejectReason.trim();
+  const isRejectDisabled = isRejectPending || !rejectReason.trim();
 
   return (
     <main className={cn('min-h-[calc(100vh-72px)] bg-[#191919]')}>
@@ -117,7 +117,7 @@ const AdminRequestDetailPage = ({
                   'flex cursor-pointer items-center justify-end gap-x-4 text-sm text-[#FC335A] transition disabled:cursor-not-allowed disabled:text-[#542730]',
                 )}
               >
-                {rejectMutation.isPending ? '거절 중...' : '등록 거절'}
+                {isRejectPending ? '거절 중...' : '등록 거절'}
                 <ArrowIcon color={isRejectDisabled ? '#542730' : '#FC335A'} />
               </button>
             </div>
@@ -129,10 +129,10 @@ const AdminRequestDetailPage = ({
             >
               <button
                 onClick={handleApprove}
-                disabled={approveMutation.isPending}
+                disabled={isApprovePending}
                 className={cn('flex cursor-pointer items-center gap-x-4 text-white transition')}
               >
-                {approveMutation.isPending ? '승인 중...' : '등록 확인'}
+                {isApprovePending ? '승인 중...' : '등록 확인'}
                 <ArrowIcon color="#FFFFFF" />
               </button>
             </div>

--- a/src/views/admin/ui/AdminRequestDetailPage.tsx
+++ b/src/views/admin/ui/AdminRequestDetailPage.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
-import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import {
@@ -14,7 +13,6 @@ import {
   useAdminRejectProject,
   useGetAdminRequest,
 } from '@/entities/project';
-import { adminQueryKeys } from '@/shared/api';
 import { ArrowIcon } from '@/shared/assets';
 import { cn } from '@/shared/utils';
 import { ProjectRequestDetailContent } from '@/widgets/project-request-detail';
@@ -29,7 +27,6 @@ const AdminRequestDetailPage = ({
   initialRequestedProjectData,
 }: AdminRequestDetailPageProps) => {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const [rejectReason, setRejectReason] = useState('');
 
   const { data: adminRequestData } = useGetAdminRequest(requestId, {
@@ -51,7 +48,6 @@ const AdminRequestDetailPage = ({
   const handleApprove = async () => {
     try {
       await approveMutation.mutateAsync(project.projectId);
-      await queryClient.invalidateQueries({ queryKey: adminQueryKeys.all() });
       router.push('/admin');
     } catch (error) {
       console.error('Failed to approve project:', error);
@@ -67,7 +63,6 @@ const AdminRequestDetailPage = ({
         projectId: project.projectId,
         reason: rejectReason,
       });
-      await queryClient.invalidateQueries({ queryKey: adminQueryKeys.all() });
       router.push('/admin');
     } catch (error) {
       console.error('Failed to reject project:', error);


### PR DESCRIPTION
## 개요 💡

PR #64 리뷰에서 `mutationKey`가 실제로 활용되는 곳이 없다는 의견이 있었습니다. TanStack Query의 `mutationKey`는 `useMutationState` 등으로 mutation 상태를 구독하거나 캐시에서 직접 조회할 때 의미가 있지만, 현재 코드베이스에서는 그런 용도로 쓰이지 않고 있었습니다. 이에 따라 전체 mutation 훅에서 `mutationKey`를 제거하고, `queryKeys.ts`에 남아 있던 mutation 전용 키도 함께 정리했습니다.

이어서 `invalidateQueries`의 Promise를 `await` 없이 호출하던 훅들을 `async/Promise.all` 패턴으로 수정하고, 뷰 레이어에서 직접 호출하던 `invalidateQueries`를 훅 내부 `onSuccess`로 이동했습니다.

추가로 Swagger 문서(`/v3/api-docs`)와 비교하여 누락된 `PATCH /api/v2/projects/{projectId}/participants` 엔드포인트를 `apiUrls.ts`에 추가했고, 기존 항목들의 순서를 HTTP 메서드(GET → POST → PATCH → DELETE) 기준으로 정렬했습니다.

## 작업내용 ⌨️

**mutationKey 및 미사용 쿼리 키 제거**
- `usePatchMyProject`, `useToggleProjectLike`, `usePostOAuthSignIn`, `usePostImageUpload`, `usePostProjectRegistration` 5개 훅에서 `mutationKey` 제거
- 각 훅의 `Omit` 타입에서 `'mutationKey'` 제거
- `queryKeys.ts`에서 mutation 전용으로만 쓰이던 키 전부 제거
  - `projectQueryKeys`: `postProjectRegistration`, `toggleProjectLike`, `patchMyProject`, `deleteMyProject`
  - `adminQueryKeys`: `patchAdminRejectProject`, `patchAdminApproveProject`
  - `authQueryKeys` 전체 제거
  - `imageQueryKeys` 전체 제거

**invalidateQueries 처리 개선**
- `usePatchMyProject`, `useDeleteMyProject`의 `onSuccess`를 `async/Promise.all` 패턴으로 수정하여 무효화 완료 후 mutation이 완료 상태로 전환되도록 수정
- `AdminRequestDetailPage`에서 직접 호출하던 `invalidateQueries`를 `useAdminApproveProject`, `useAdminRejectProject` 훅 내부 `onSuccess`로 이동
- `AdminRequestDetailPage`에서 mutation 훅을 구조분해할당으로 변경

**apiUrls.ts 정리**
- `PATCH /api/v2/projects/{projectId}/participants` (`patchProjectParticipants`) 엔드포인트 추가
- `projectUrl` 항목을 GET → POST → PATCH → DELETE 순으로 정렬

## 관련 이슈 🚨

- PR #64 리뷰 코멘트: https://github.com/themoment-team/everygsm-client-v2/pull/64#discussion_r3331110784
