### PR TITLE
[mypage] 요청 중인 프로젝트 수정·삭제 액션 메뉴 추가 및 로고 버그 수정

### DIFF
--- a/src/entities/project/ui/ProjectRequestCard.tsx
+++ b/src/entities/project/ui/ProjectRequestCard.tsx
@@ -9,11 +9,13 @@ import type { ProjectType } from '../model/types';
 interface ProjectRequestCardProps {
   data: ProjectType;
   detailPathPrefix?: '/admin/request' | '/mypage/request';
+  actionButton?: React.ReactNode;
 }
 
 const ProjectRequestCard = ({
   data,
   detailPathPrefix = '/mypage/request',
+  actionButton,
 }: ProjectRequestCardProps) => {
   const { logo, title, affiliation, createdAt, status, projectId } = data;
   const requestStatusMeta = getProjectRequestStatusMeta(status);
@@ -22,35 +24,40 @@ const ProjectRequestCard = ({
   const displayAffiliation = affiliation ?? '소속 정보 없음';
 
   return (
-    <Link
-      href={`${detailPathPrefix}/${projectId}`}
+    <div
       className={cn(
-        'flex w-full max-w-295 justify-between rounded-xl bg-[rgba(34,34,34,0.50)] p-6 shadow-[inset_0_0_0_1px_#2F2F2F] backdrop-blur-[1.125rem]',
+        'flex w-full max-w-295 items-center justify-between gap-x-7 rounded-xl bg-[rgba(34,34,34,0.50)] p-6 shadow-[inset_0_0_0_1px_#2F2F2F] backdrop-blur-[1.125rem]',
       )}
     >
-      <div className={cn('flex items-center gap-x-4')}>
-        {hasLogo ? (
-          <div className={cn('relative h-14 w-14 overflow-hidden rounded-full')}>
-            <Image src={logo} alt={title} fill sizes="56px" className={cn('object-cover')} />
+      <Link
+        href={`${detailPathPrefix}/${projectId}`}
+        className={cn('flex flex-1 items-center justify-between')}
+      >
+        <div className={cn('flex items-center gap-x-4')}>
+          {hasLogo ? (
+            <div className={cn('relative h-14 w-14 overflow-hidden rounded-full')}>
+              <Image src={logo} alt={title} fill sizes="56px" className={cn('object-cover')} />
+            </div>
+          ) : (
+            <div aria-hidden className={cn('h-14 w-14 rounded-full bg-[#4F4F4F]')} />
+          )}
+          <div className={cn('flex flex-col gap-y-2')}>
+            <h3 className={cn('text-xl leading-6 font-semibold text-white')}>{title}</h3>
+            <p className={cn('text-sm leading-4.25 text-[#9A9A9A]')}>{displayAffiliation}</p>
           </div>
-        ) : (
-          <div aria-hidden className={cn('h-14 w-14 rounded-full bg-[#4F4F4F]')} />
-        )}
-        <div className={cn('flex flex-col gap-y-2')}>
-          <h3 className={cn('text-xl leading-6 font-semibold text-white')}>{title}</h3>
-          <p className={cn('text-sm leading-4.25 text-[#9A9A9A]')}>{displayAffiliation}</p>
         </div>
-      </div>
-      <div className={cn('flex items-center gap-x-4')}>
-        <p className={cn('text-sm leading-4.25 text-[#9A9A9A]')}>{formattedDate}</p>
-        <p className={cn('text-xl leading-6 font-semibold')}>
-          <span className={cn('text-white')}>요청 상태: </span>
-          <span className={cn(requestStatusMeta.textColorClassName)}>
-            {requestStatusMeta.label}
-          </span>
-        </p>
-      </div>
-    </Link>
+        <div className={cn('flex items-center gap-x-4')}>
+          <p className={cn('text-sm leading-4.25 text-[#9A9A9A]')}>{formattedDate}</p>
+          <p className={cn('text-xl leading-6 font-semibold')}>
+            <span className={cn('text-white')}>요청 상태: </span>
+            <span className={cn(requestStatusMeta.textColorClassName)}>
+              {requestStatusMeta.label}
+            </span>
+          </p>
+        </div>
+      </Link>
+      {actionButton}
+    </div>
   );
 };
 

--- a/src/views/edit-project/ui/EditProjectPage.tsx
+++ b/src/views/edit-project/ui/EditProjectPage.tsx
@@ -23,8 +23,18 @@ const EditProjectPage = ({ projectId, initialProjectData }: EditProjectPageProps
   });
   const project = myProjectData?.data ?? initialProjectData?.data;
 
+  // 백엔드가 logo를 pre-signed URL로 반환하므로 키 경로만 추출
+  const extractLogoKey = (logo?: string) => {
+    if (!logo) return logo;
+    try {
+      return new URL(logo).pathname.slice(1);
+    } catch {
+      return logo;
+    }
+  };
+
   const initialData = {
-    logo: project?.logo,
+    logo: extractLogoKey(project?.logo),
     title: project?.title,
     affiliation: project?.affiliation ?? '',
     startYear: project?.startYear,

--- a/src/views/edit-project/ui/EditProjectPage.tsx
+++ b/src/views/edit-project/ui/EditProjectPage.tsx
@@ -27,9 +27,10 @@ const EditProjectPage = ({ projectId, initialProjectData }: EditProjectPageProps
   const extractLogoKey = (logo?: string) => {
     if (!logo) return logo;
     try {
-      return new URL(logo).pathname.slice(1);
+      const { pathname } = new URL(logo);
+      return pathname.startsWith('/') ? pathname.slice(1) : pathname;
     } catch {
-      return logo;
+      return logo.startsWith('/') ? logo.slice(1) : logo;
     }
   };
 

--- a/src/views/mypage/ui/MyPage.tsx
+++ b/src/views/mypage/ui/MyPage.tsx
@@ -97,7 +97,7 @@ const MyPage = ({
             <HeroSection
               title={
                 <>
-                  <span className={cn('text-[#FC335A]')}>{displayName}</span> 님이 등록 요청한
+                  <span className={cn('text-[#FC335A]')}>{displayName}</span> 님이 등록/수정 요청한
                   프로젝트
                 </>
               }
@@ -107,7 +107,16 @@ const MyPage = ({
               onChange={setSelectedRequestStatus}
             />
           </div>
-          <ProjectRequestList projects={requestProjects} />
+          <ProjectRequestList
+            projects={requestProjects}
+            renderActionButton={(project) => (
+              <ProjectActionMenu
+                projectId={project.projectId}
+                editLabel="프로젝트 등록내용 수정하기"
+                deleteLabel="프로젝트 등록 요청 삭제"
+              />
+            )}
+          />
         </div>
       </div>
     </main>

--- a/src/views/mypage/ui/ProjectActionMenu.tsx
+++ b/src/views/mypage/ui/ProjectActionMenu.tsx
@@ -32,8 +32,8 @@ const ProjectActionMenu = ({
     if (!isOpen && buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect();
       setDropdownStyle({
-        top: rect.bottom + 8,
-        right: window.innerWidth - rect.right,
+        top: rect.top + 8,
+        right: window.innerWidth - rect.right - 4,
       });
     }
     setIsOpen((prev) => !prev);

--- a/src/views/mypage/ui/ProjectActionMenu.tsx
+++ b/src/views/mypage/ui/ProjectActionMenu.tsx
@@ -48,14 +48,16 @@ const ProjectActionMenu = ({
       setIsOpen(false);
     };
 
-    const handleScroll = () => setIsOpen(false);
+    const handleClose = () => setIsOpen(false);
 
     document.addEventListener('mousedown', handleOutside);
-    window.addEventListener('scroll', handleScroll, { passive: true, capture: true });
+    window.addEventListener('scroll', handleClose, { passive: true, capture: true });
+    window.addEventListener('resize', handleClose);
 
     return () => {
       document.removeEventListener('mousedown', handleOutside);
-      window.removeEventListener('scroll', handleScroll, { capture: true });
+      window.removeEventListener('scroll', handleClose, { capture: true });
+      window.removeEventListener('resize', handleClose);
     };
   }, [isOpen]);
 

--- a/src/views/mypage/ui/ProjectActionMenu.tsx
+++ b/src/views/mypage/ui/ProjectActionMenu.tsx
@@ -1,25 +1,63 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import Link from 'next/link';
 
+import { createPortal } from 'react-dom';
+
 import { DeleteConfirmModal } from '@/features/delete-project';
 import { ArrowIcon, HamburgerIcon } from '@/shared/assets';
-import { useOnClickOutside } from '@/shared/hooks';
 import { useModalStore } from '@/shared/stores';
 import { cn } from '@/shared/utils';
 
 interface ProjectActionMenuProps {
   projectId: number;
+  editLabel?: string;
+  deleteLabel?: string;
 }
 
-const ProjectActionMenu = ({ projectId }: ProjectActionMenuProps) => {
+const ProjectActionMenu = ({
+  projectId,
+  editLabel = '프로젝트 수정하기',
+  deleteLabel = '프로젝트 삭제',
+}: ProjectActionMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const { openModal } = useModalStore();
 
-  useOnClickOutside(menuRef as React.RefObject<HTMLElement>, () => setIsOpen(false));
+  const handleToggle = () => {
+    if (!isOpen && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setDropdownStyle({
+        top: rect.bottom + 8,
+        right: window.innerWidth - rect.right,
+      });
+    }
+    setIsOpen((prev) => !prev);
+  };
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (buttonRef.current?.contains(target) || dropdownRef.current?.contains(target)) return;
+      setIsOpen(false);
+    };
+
+    const handleScroll = () => setIsOpen(false);
+
+    document.addEventListener('mousedown', handleOutside);
+    window.addEventListener('scroll', handleScroll, { passive: true, capture: true });
+
+    return () => {
+      document.removeEventListener('mousedown', handleOutside);
+      window.removeEventListener('scroll', handleScroll, { capture: true });
+    };
+  }, [isOpen]);
 
   const handleDelete = () => {
     setIsOpen(false);
@@ -27,45 +65,48 @@ const ProjectActionMenu = ({ projectId }: ProjectActionMenuProps) => {
   };
 
   return (
-    <div ref={menuRef} className={cn('relative')}>
+    <>
       <button
-        onClick={() => {
-          setIsOpen((prev) => !prev);
-        }}
+        ref={buttonRef}
+        onClick={handleToggle}
         className={cn('cursor-pointer')}
         aria-label="프로젝트 메뉴 열기"
       >
         <HamburgerIcon />
       </button>
 
-      {isOpen && (
-        <div
-          className={cn(
-            'absolute top-3 right-2 z-50 flex flex-col items-end gap-2 rounded-xl bg-[rgba(34,34,34,0.50)] p-3 shadow-[inset_0_0_0_1px_#2F2F2F] backdrop-blur-[1.125rem]',
-          )}
-        >
-          <Link
-            href={`/mypage/edit/${projectId}`}
-            onClick={() => setIsOpen(false)}
+      {isOpen &&
+        createPortal(
+          <div
+            ref={dropdownRef}
+            style={dropdownStyle}
             className={cn(
-              'flex cursor-pointer items-center gap-4 px-3 py-1.5 text-base leading-6 font-medium whitespace-nowrap text-white',
+              'fixed z-50 flex flex-col items-end gap-2 rounded-xl bg-[rgba(34,34,34,0.50)] p-3 shadow-[inset_0_0_0_1px_#2F2F2F] backdrop-blur-[1.125rem]',
             )}
           >
-            프로젝트 수정하기
-            <ArrowIcon />
-          </Link>
-          <button
-            onClick={handleDelete}
-            className={cn(
-              'flex cursor-pointer items-center gap-4 px-3 py-1.5 text-base leading-6 font-medium whitespace-nowrap text-white',
-            )}
-          >
-            프로젝트 삭제
-            <ArrowIcon />
-          </button>
-        </div>
-      )}
-    </div>
+            <Link
+              href={`/mypage/edit/${projectId}`}
+              onClick={() => setIsOpen(false)}
+              className={cn(
+                'flex cursor-pointer items-center gap-4 px-3 py-1.5 text-base leading-6 font-medium whitespace-nowrap text-white',
+              )}
+            >
+              {editLabel}
+              <ArrowIcon />
+            </Link>
+            <button
+              onClick={handleDelete}
+              className={cn(
+                'flex cursor-pointer items-center gap-4 px-3 py-1.5 text-base leading-6 font-medium whitespace-nowrap text-white',
+              )}
+            >
+              {deleteLabel}
+              <ArrowIcon />
+            </button>
+          </div>,
+          document.body,
+        )}
+    </>
   );
 };
 

--- a/src/widgets/project-request-list/ui/ProjectRequestList.tsx
+++ b/src/widgets/project-request-list/ui/ProjectRequestList.tsx
@@ -6,9 +6,14 @@ import { cn } from '@/shared/utils';
 interface ProjectRequestListProps {
   projects: ProjectType[];
   detailPathPrefix?: '/admin/request' | '/mypage/request';
+  renderActionButton?: (project: ProjectType) => React.ReactNode;
 }
 
-const ProjectRequestList = ({ projects, detailPathPrefix }: ProjectRequestListProps) => {
+const ProjectRequestList = ({
+  projects,
+  detailPathPrefix,
+  renderActionButton,
+}: ProjectRequestListProps) => {
   return (
     <div className={cn('mx-auto flex w-full max-w-295 flex-col gap-y-4')}>
       {projects.map((project) => (
@@ -16,6 +21,7 @@ const ProjectRequestList = ({ projects, detailPathPrefix }: ProjectRequestListPr
           key={project.projectId}
           data={project}
           detailPathPrefix={detailPathPrefix}
+          actionButton={renderActionButton?.(project)}
         />
       ))}
     </div>


### PR DESCRIPTION
## 개요 💡

마이페이지의 "등록/수정 요청한 프로젝트" 섹션에서 PENDING·REJECTED 상태의 프로젝트에도 수정 및 삭제 액션 메뉴를 제공합니다. 기존에는 승인된 프로젝트에만 수정·삭제 기능이 있었습니다.

아울러 수정 페이지에서 로고를 변경하지 않고 제출할 때, 백엔드가 반환하는 pre-signed URL이 그대로 요청 바디에 포함되던 버그를 수정합니다.

## 작업내용 ⌨️

**요청 중인 프로젝트 액션 메뉴 추가**

- `ProjectRequestCard`: 전체를 감싸던 `<Link>`를 `<div>`로 변경하고 정보 영역만 `<Link>`로 구성, `actionButton` slot 추가
- `ProjectRequestList`: `renderActionButton` prop 추가 (`ProjectList`와 동일한 패턴)
- `ProjectActionMenu`: `editLabel` · `deleteLabel` props 추가로 컨텍스트에 맞는 텍스트 표시
- `MyPage`: 요청 목록에 액션 메뉴 연결, 섹션 타이틀을 "등록/수정 요청한 프로젝트"로 변경

**드롭다운 잘림 버그 수정**

- `backdrop-filter`가 stacking context를 생성해 다음 카드가 드롭다운을 가리는 문제 해결
- `createPortal`로 드롭다운을 `document.body`에 렌더링, `getBoundingClientRect()`로 버튼 위치 계산 후 `fixed` 포지셔닝 적용

**수정 페이지 로고 pre-signed URL 버그 수정**

- 백엔드 `ProjectResDto.logo`는 pre-signed S3 URL을 반환하지만, 수정 API는 키 경로(`images/…`)만 허용
- `EditProjectPage`에서 `new URL(logo).pathname.slice(1)`로 키만 추출해 `initialData.logo`에 세팅

## 스크린샷/동영상 📸

<!-- 요청 중인 프로젝트 카드에 액션 메뉴가 표시되는 화면을 첨부해주세요. -->

## 리뷰 요청사항 👀

- `ProjectActionMenu`의 드롭다운을 portal로 변경했습니다. 스크롤 시 닫히는 동작이 기존 UX와 맞는지 확인 부탁드립니다.
- `extractLogoKey`가 `try/catch`로 일반 키 문자열도 그대로 통과시키는 방식인데, 더 명시적인 처리가 필요한지 검토 부탁드립니다.
