### PR TITLE
[Feat] 프로젝트 목록 정렬 기능 추가

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 
 import { getProjects } from '@/entities/project/index.server';
 import { getMyInfo } from '@/entities/user/index.server';
+import { DEFAULT_PROJECT_SORT, isProjectSortType } from '@/features/project-sort-select';
 import { SuspenseFallback } from '@/shared/ui';
 import { HomePage } from '@/views/home';
 
@@ -14,10 +15,13 @@ export const metadata: Metadata = {
   },
 };
 
-const Home = async () => {
+const Home = async ({ searchParams }: { searchParams: Promise<{ sort?: string }> }) => {
+  const { sort } = await searchParams;
+  const resolvedSort = isProjectSortType(sort) ? sort : DEFAULT_PROJECT_SORT;
+
   const [initialUserInfoData, initialProjectsData] = await Promise.all([
     getMyInfo(),
-    getProjects(),
+    getProjects(resolvedSort),
   ]);
 
   return (

--- a/src/entities/project/api/getProjects.ts
+++ b/src/entities/project/api/getProjects.ts
@@ -1,11 +1,14 @@
 import { projectUrl } from '@/shared/api';
 import { apiFetcher } from '@/shared/api/fetcher';
+import type { ProjectSortType } from '@/shared/types';
 
 import { ProjectsListResponseType } from '../model/types';
 
-export const getProjects = async (): Promise<ProjectsListResponseType | undefined> => {
+export const getProjects = async (
+  sort?: ProjectSortType,
+): Promise<ProjectsListResponseType | undefined> => {
   return apiFetcher<ProjectsListResponseType>({
-    endpoint: projectUrl.getProjects(),
+    endpoint: projectUrl.getProjects(sort),
     context: 'getProjects',
     errorMessage: '프로젝트 목록 조회 실패:',
   });

--- a/src/entities/project/model/useDeleteMyProject.ts
+++ b/src/entities/project/model/useDeleteMyProject.ts
@@ -12,7 +12,7 @@ export const useDeleteMyProject = () => {
         queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyProjects() }),
         queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyPendingProjects() }),
         queryClient.invalidateQueries({ queryKey: projectQueryKeys.getMyRejectedProjects() }),
-        queryClient.invalidateQueries({ queryKey: projectQueryKeys.getProjects() }),
+        queryClient.invalidateQueries({ queryKey: projectQueryKeys.getProjectsList() }),
       ]);
     },
   });

--- a/src/entities/project/model/useGetProjects.ts
+++ b/src/entities/project/model/useGetProjects.ts
@@ -1,17 +1,20 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { keepPreviousData, useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 import { get, projectQueryKeys, projectUrl } from '@/shared/api';
+import type { ProjectSortType } from '@/shared/types';
 import { minutesToMs } from '@/shared/utils';
 
 import { ProjectsListResponseType } from './types';
 
 export const useGetProjects = (
+  sort?: ProjectSortType,
   options?: Omit<UseQueryOptions<ProjectsListResponseType>, 'queryKey' | 'queryFn'>,
 ) =>
   useQuery({
-    queryKey: projectQueryKeys.getProjects(),
-    queryFn: () => get<ProjectsListResponseType>(projectUrl.getProjects()),
+    queryKey: projectQueryKeys.getProjects(sort),
+    queryFn: () => get<ProjectsListResponseType>(projectUrl.getProjects(sort)),
     staleTime: minutesToMs(5),
     gcTime: minutesToMs(10),
+    placeholderData: keepPreviousData,
     ...options,
   });

--- a/src/features/like-project/ui/LikeButton.tsx
+++ b/src/features/like-project/ui/LikeButton.tsx
@@ -64,8 +64,9 @@ const LikeButton = ({ isLiked, projectId }: LikeButtonProps) => {
     onMutate: () => setLocalIsLiked((prev) => !prev), // 낙관적 업데이트: 좋아요 상태를 즉시 반전
     onError: () => setLocalIsLiked((prev) => !prev), // 에러 발생 시 직전 상태로 롤백
     onSuccess: (_, currentIsLiked) => {
-      queryClient.setQueryData<ProjectsListResponseType>(projectQueryKeys.getProjects(), (old) =>
-        updateProjectsListLike(old, currentIsLiked),
+      queryClient.setQueriesData<ProjectsListResponseType>(
+        { queryKey: projectQueryKeys.getProjectsList() },
+        (old) => updateProjectsListLike(old, currentIsLiked),
       );
       queryClient.setQueryData<MyProjectsListResponseType>(
         projectQueryKeys.getMyProjects(),

--- a/src/features/project-sort-select/index.ts
+++ b/src/features/project-sort-select/index.ts
@@ -1,0 +1,3 @@
+export { PROJECT_SORT_OPTIONS } from './model/constants';
+export * from './model/types';
+export { default as ProjectSortSelect } from './ui/ProjectSortSelect';

--- a/src/features/project-sort-select/index.ts
+++ b/src/features/project-sort-select/index.ts
@@ -1,3 +1,3 @@
-export { PROJECT_SORT_OPTIONS } from './model/constants';
+export { DEFAULT_PROJECT_SORT, isProjectSortType, PROJECT_SORT_OPTIONS } from './model/constants';
 export * from './model/types';
 export { default as ProjectSortSelect } from './ui/ProjectSortSelect';

--- a/src/features/project-sort-select/model/constants.ts
+++ b/src/features/project-sort-select/model/constants.ts
@@ -1,7 +1,12 @@
 import type { ProjectSortType } from './types';
 
 export const PROJECT_SORT_OPTIONS: { value: ProjectSortType; label: string }[] = [
-  { value: 'LIKE', label: '좋아요순' },
-  { value: 'LATEST', label: '최신순' },
+  { value: 'LIKES', label: '좋아요순' },
+  { value: 'NEWEST', label: '최신순' },
   { value: 'OLDEST', label: '오래된순' },
 ];
+
+export const DEFAULT_PROJECT_SORT: ProjectSortType = 'NEWEST';
+
+export const isProjectSortType = (value?: string | null): value is ProjectSortType =>
+  PROJECT_SORT_OPTIONS.some((option) => option.value === value);

--- a/src/features/project-sort-select/model/constants.ts
+++ b/src/features/project-sort-select/model/constants.ts
@@ -1,0 +1,7 @@
+import type { ProjectSortType } from './types';
+
+export const PROJECT_SORT_OPTIONS: { value: ProjectSortType; label: string }[] = [
+  { value: 'LIKE', label: '좋아요순' },
+  { value: 'LATEST', label: '최신순' },
+  { value: 'OLDEST', label: '오래된순' },
+];

--- a/src/features/project-sort-select/model/types.ts
+++ b/src/features/project-sort-select/model/types.ts
@@ -1,0 +1,1 @@
+export type ProjectSortType = 'LIKE' | 'LATEST' | 'OLDEST';

--- a/src/features/project-sort-select/model/types.ts
+++ b/src/features/project-sort-select/model/types.ts
@@ -1,1 +1,1 @@
-export type ProjectSortType = 'LIKE' | 'LATEST' | 'OLDEST';
+export type { ProjectSortType } from '@/shared/types';

--- a/src/features/project-sort-select/ui/ProjectSortSelect.tsx
+++ b/src/features/project-sort-select/ui/ProjectSortSelect.tsx
@@ -28,16 +28,13 @@ const ProjectSortSelect = ({ selectedSort, onChange }: ProjectSortSelectProps) =
   };
 
   return (
-    <div
-      ref={containerRef}
-      className={cn(
-        'flex w-45 flex-col items-start gap-2.5 rounded-xl border border-[#2F2F2F] bg-[rgba(34,34,34,0.5)] px-4 py-3 shadow-[0px_0px_16px_0px_rgba(10,6,29,0.25)] backdrop-blur-[1.125rem]',
-      )}
-    >
+    <div ref={containerRef} className={cn('relative w-45')}>
       <button
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
-        className={cn('flex w-full items-center justify-between')}
+        className={cn(
+          'flex w-full items-center justify-between rounded-xl border border-[#2F2F2F] bg-[rgba(34,34,34,0.5)] px-4 py-3 shadow-[0px_0px_16px_0px_rgba(10,6,29,0.25)] backdrop-blur-[1.125rem]',
+        )}
       >
         <span className={cn('text-base font-medium tracking-[-0.03em] text-white')}>
           {selectedLabel}
@@ -48,7 +45,11 @@ const ProjectSortSelect = ({ selectedSort, onChange }: ProjectSortSelectProps) =
       </button>
 
       {isOpen && (
-        <>
+        <div
+          className={cn(
+            'absolute top-full left-0 z-10 mt-2 flex w-full flex-col items-start gap-2.5 rounded-xl border border-[#2F2F2F] bg-[rgba(34,34,34,0.5)] px-4 py-3 shadow-[0px_0px_16px_0px_rgba(10,6,29,0.25)] backdrop-blur-[1.125rem]',
+          )}
+        >
           <div className={cn('flex w-full items-center gap-4')}>
             <span className={cn('text-xs text-[#6A6A6A]')}>정렬</span>
             <div className={cn('h-px flex-1 bg-[#2F2F2F]')} />
@@ -67,7 +68,7 @@ const ProjectSortSelect = ({ selectedSort, onChange }: ProjectSortSelectProps) =
               {option.label}
             </button>
           ))}
-        </>
+        </div>
       )}
     </div>
   );

--- a/src/features/project-sort-select/ui/ProjectSortSelect.tsx
+++ b/src/features/project-sort-select/ui/ProjectSortSelect.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useRef, useState } from 'react';
+
+import { ArrowIcon } from '@/shared/assets';
+import { useOnClickOutside } from '@/shared/hooks';
+import { cn } from '@/shared/utils';
+
+import { PROJECT_SORT_OPTIONS } from '../model/constants';
+import type { ProjectSortType } from '../model/types';
+
+interface ProjectSortSelectProps {
+  selectedSort: ProjectSortType;
+  onChange: (sort: ProjectSortType) => void;
+}
+
+const ProjectSortSelect = ({ selectedSort, onChange }: ProjectSortSelectProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useOnClickOutside(containerRef as React.RefObject<HTMLElement>, () => setIsOpen(false));
+
+  const selectedLabel = PROJECT_SORT_OPTIONS.find((option) => option.value === selectedSort)?.label;
+
+  const handleSelect = (sort: ProjectSortType) => {
+    onChange(sort);
+    setIsOpen(false);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        'flex w-45 flex-col items-start gap-2.5 rounded-xl border border-[#2F2F2F] bg-[rgba(34,34,34,0.5)] px-4 py-3 shadow-[0px_0px_16px_0px_rgba(10,6,29,0.25)] backdrop-blur-[1.125rem]',
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className={cn('flex w-full items-center justify-between')}
+      >
+        <span className={cn('text-base font-medium tracking-[-0.03em] text-white')}>
+          {selectedLabel}
+        </span>
+        <span className={cn(isOpen ? '-rotate-90' : 'rotate-90')}>
+          <ArrowIcon />
+        </span>
+      </button>
+
+      {isOpen && (
+        <>
+          <div className={cn('flex w-full items-center gap-4')}>
+            <span className={cn('text-xs text-[#6A6A6A]')}>정렬</span>
+            <div className={cn('h-px flex-1 bg-[#2F2F2F]')} />
+          </div>
+
+          {PROJECT_SORT_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => handleSelect(option.value)}
+              className={cn(
+                'w-full py-1 text-left text-sm font-medium tracking-[-0.03em]',
+                option.value === selectedSort ? 'text-[#FC335A]' : 'text-white',
+              )}
+            >
+              {option.label}
+            </button>
+          ))}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ProjectSortSelect;

--- a/src/shared/api/apiUrls.ts
+++ b/src/shared/api/apiUrls.ts
@@ -1,3 +1,5 @@
+import type { ProjectSortType } from '@/shared/types';
+
 export const adminUrl = {
   getAdminRequests: () => '/api/v2/admin/requests',
   getAdminRequest: (id: number) => `/api/v2/admin/requests/${id}`,
@@ -15,7 +17,8 @@ export const userUrl = {
 } as const;
 
 export const projectUrl = {
-  getProjects: () => '/api/v2/projects',
+  getProjects: (sort?: ProjectSortType) =>
+    sort ? `/api/v2/projects?sort=${sort}` : '/api/v2/projects',
   getMyProjects: () => '/api/v2/projects/my',
   getMyProject: (id?: number) => `/api/v2/projects/my/${id}`,
   getMyRejectedProjects: () => '/api/v2/projects/my/rejected',

--- a/src/shared/api/queryKeys.ts
+++ b/src/shared/api/queryKeys.ts
@@ -1,3 +1,5 @@
+import type { ProjectSortType } from '@/shared/types';
+
 export const adminQueryKeys = {
   all: () => ['admin'] as const,
   getAdminRequests: () => ['admin', 'requests', 'list'] as const,
@@ -6,7 +8,8 @@ export const adminQueryKeys = {
 
 export const projectQueryKeys = {
   all: () => ['projects'] as const,
-  getProjects: () => ['projects', 'list'] as const,
+  getProjectsList: () => ['projects', 'list'] as const,
+  getProjects: (sort?: ProjectSortType) => ['projects', 'list', sort] as const,
   getMyProjects: () => ['projects', 'my', 'list'] as const,
   getMyProject: (projectId?: number) => ['projects', 'my', 'detail', projectId] as const,
   getMyRejectedProjects: () => ['projects', 'my', 'rejected'] as const,

--- a/src/shared/types/base.ts
+++ b/src/shared/types/base.ts
@@ -1,3 +1,5 @@
+export type ProjectSortType = 'LIKES' | 'NEWEST' | 'OLDEST';
+
 export interface BaseApiResponse {
   status: string;
   code: number;

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 
 import { toast } from 'sonner';
 
@@ -26,17 +26,24 @@ interface HomePageProps {
 }
 
 const HomePage = ({ initialUserInfoData, initialProjectsData }: HomePageProps) => {
-  const router = useRouter();
-  const pathname = usePathname();
   const searchParams = useSearchParams();
-
   const sortParam = searchParams.get('sort');
-  const sort: ProjectSortType = isProjectSortType(sortParam) ? sortParam : DEFAULT_PROJECT_SORT;
+  const initialSort: ProjectSortType = isProjectSortType(sortParam)
+    ? sortParam
+    : DEFAULT_PROJECT_SORT;
+
+  const [sort, setSort] = useState<ProjectSortType>(initialSort);
+
+  // 실제 네비게이션/Link 등 외부 요인으로 URL의 sort가 바뀌면 상태를 동기화
+  useEffect(() => {
+    setSort(initialSort);
+  }, [initialSort]);
 
   const handleSortChange = (nextSort: ProjectSortType) => {
-    const params = new URLSearchParams(searchParams.toString());
+    setSort(nextSort);
+    const params = new URLSearchParams(window.location.search);
     params.set('sort', nextSort);
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    window.history.replaceState(null, '', `${window.location.pathname}?${params.toString()}`);
   };
 
   const hasAccessToken = Boolean(getCookie(COOKIE_KEYS.ACCESS_TOKEN));
@@ -45,7 +52,9 @@ const HomePage = ({ initialUserInfoData, initialProjectsData }: HomePageProps) =
     initialData: initialUserInfoData,
     enabled: hasAccessToken,
   });
-  const { data: projectsData } = useGetProjects(sort, { initialData: initialProjectsData });
+  const { data: projectsData } = useGetProjects(sort, {
+    initialData: sort === initialSort ? initialProjectsData : undefined,
+  });
 
   const isLoggedIn = Boolean(userInfoData?.data?.id);
   const projects = projectsData?.data.projects ?? [];

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -52,7 +52,7 @@ const HomePage = ({ initialUserInfoData, initialProjectsData }: HomePageProps) =
   return (
     <main className="min-h-[calc(100vh-72px)] bg-[#191919]">
       <div className={cn('flex flex-col gap-y-10 px-15 py-10')}>
-        <div className={cn('flex items-end gap-6')}>
+        <div className={cn('mx-auto flex w-full max-w-295 items-end gap-6')}>
           <HeroSection
             title={`GSM의 프로젝트를 한 눈에,\nEveryGSM에서 간편하게 확인해보세요!`}
             description={`EveryGSM은 GSM의 프로젝트들을 한 곳에 모아 트래픽을 집중시키기 위한 서비스로,\n사용자가 GSM의 사이트를 보다 쉽게 방문하기 위해 만들어졌습니다.`}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { toast } from 'sonner';
 
 import { ProjectsListResponseType, useGetProjects } from '@/entities/project';
 import { useGetMyInfo, UserInfoResponseType } from '@/entities/user';
+import { ProjectSortSelect, ProjectSortType } from '@/features/project-sort-select';
 import { COOKIE_KEYS } from '@/shared/constants';
 import { useHandleErrorQueryToast } from '@/shared/hooks';
 import { cn, getCookie } from '@/shared/utils';
@@ -18,6 +19,8 @@ interface HomePageProps {
 }
 
 const HomePage = ({ initialUserInfoData, initialProjectsData }: HomePageProps) => {
+  const [sort, setSort] = useState<ProjectSortType>('LATEST');
+
   const hasAccessToken = Boolean(getCookie(COOKIE_KEYS.ACCESS_TOKEN));
 
   const { data: userInfoData } = useGetMyInfo({
@@ -49,10 +52,15 @@ const HomePage = ({ initialUserInfoData, initialProjectsData }: HomePageProps) =
   return (
     <main className="min-h-[calc(100vh-72px)] bg-[#191919]">
       <div className={cn('flex flex-col gap-y-10 px-15 py-10')}>
-        <HeroSection
-          title={`GSM의 프로젝트를 한 눈에,\nEveryGSM에서 간편하게 확인해보세요!`}
-          description={`EveryGSM은 GSM의 프로젝트들을 한 곳에 모아 트래픽을 집중시키기 위한 서비스로,\n사용자가 GSM의 사이트를 보다 쉽게 방문하기 위해 만들어졌습니다.`}
-        />
+        <div className={cn('flex items-end gap-6')}>
+          <HeroSection
+            title={`GSM의 프로젝트를 한 눈에,\nEveryGSM에서 간편하게 확인해보세요!`}
+            description={`EveryGSM은 GSM의 프로젝트들을 한 곳에 모아 트래픽을 집중시키기 위한 서비스로,\n사용자가 GSM의 사이트를 보다 쉽게 방문하기 위해 만들어졌습니다.`}
+          />
+          <div className={cn('flex flex-row-reverse')}>
+            <ProjectSortSelect selectedSort={sort} onChange={setSort} />
+          </div>
+        </div>
         <ProjectList projects={projects} showRegisterCard={isLoggedIn} />
       </div>
     </main>

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import { toast } from 'sonner';
 
 import { ProjectsListResponseType, useGetProjects } from '@/entities/project';
 import { useGetMyInfo, UserInfoResponseType } from '@/entities/user';
-import { ProjectSortSelect, ProjectSortType } from '@/features/project-sort-select';
+import {
+  DEFAULT_PROJECT_SORT,
+  isProjectSortType,
+  ProjectSortSelect,
+  ProjectSortType,
+} from '@/features/project-sort-select';
 import { COOKIE_KEYS } from '@/shared/constants';
 import { useHandleErrorQueryToast } from '@/shared/hooks';
 import { cn, getCookie } from '@/shared/utils';
@@ -19,7 +26,18 @@ interface HomePageProps {
 }
 
 const HomePage = ({ initialUserInfoData, initialProjectsData }: HomePageProps) => {
-  const [sort, setSort] = useState<ProjectSortType>('LATEST');
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const sortParam = searchParams.get('sort');
+  const sort: ProjectSortType = isProjectSortType(sortParam) ? sortParam : DEFAULT_PROJECT_SORT;
+
+  const handleSortChange = (nextSort: ProjectSortType) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('sort', nextSort);
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  };
 
   const hasAccessToken = Boolean(getCookie(COOKIE_KEYS.ACCESS_TOKEN));
 
@@ -27,7 +45,7 @@ const HomePage = ({ initialUserInfoData, initialProjectsData }: HomePageProps) =
     initialData: initialUserInfoData,
     enabled: hasAccessToken,
   });
-  const { data: projectsData } = useGetProjects({ initialData: initialProjectsData });
+  const { data: projectsData } = useGetProjects(sort, { initialData: initialProjectsData });
 
   const isLoggedIn = Boolean(userInfoData?.data?.id);
   const projects = projectsData?.data.projects ?? [];
@@ -58,7 +76,7 @@ const HomePage = ({ initialUserInfoData, initialProjectsData }: HomePageProps) =
             description={`EveryGSM은 GSM의 프로젝트들을 한 곳에 모아 트래픽을 집중시키기 위한 서비스로,\n사용자가 GSM의 사이트를 보다 쉽게 방문하기 위해 만들어졌습니다.`}
           />
           <div className={cn('flex flex-row-reverse')}>
-            <ProjectSortSelect selectedSort={sort} onChange={setSort} />
+            <ProjectSortSelect selectedSort={sort} onChange={handleSortChange} />
           </div>
         </div>
         <ProjectList projects={projects} showRegisterCard={isLoggedIn} />


### PR DESCRIPTION
## 개요 💡

홈 화면 프로젝트 목록에 정렬 기능을 추가합니다. 사용자가 정렬 옵션(최신순/좋아요순/오래된순)을 선택하면 해당 기준으로 서버에 다시 요청해 목록을 갱신합니다. 정렬 상태는 URL 쿼리(`?sort=`)에 담아 새로고침·공유 시에도 유지되고 서버에서 정확한 정렬로 렌더링되도록 했습니다.

## 작업내용 ⌨️

- **정렬 UI 추가**: `ProjectSortSelect` 드롭다운 컴포넌트(`features/project-sort-select`)와 홈 화면 연동.
- **서버사이드 정렬 연동**:
  - `useGetProjects(sort)`가 `sort`를 쿼리 키와 요청 파라미터(`/api/v2/projects?sort=`)에 반영 → 정렬 변경 시 새 키로 자동 재요청·재렌더링.
  - 전환 중 목록이 빈 화면으로 깜빡이지 않도록 `placeholderData: keepPreviousData` 적용.
- **URL 기반 상태 관리**: 정렬 상태를 `useState` 대신 URL `searchParams`로 관리. 선택 시 `router.replace`로 갱신하고, 서버 컴포넌트(`app/page.tsx`)가 `searchParams`를 검증해 해당 정렬로 prefetch.
- **타입 정합성**: `ProjectSortType` 값을 백엔드 값(`LIKES`/`NEWEST`/`OLDEST`)과 일치시키고, FSD 레이어 경계 준수를 위해 `shared/types`로 이동(features는 재-export). 잘못된 쿼리값 방어용 `isProjectSortType` 가드 추가(기본값 `NEWEST`).
- **캐시 갱신 정정**: 정렬이 쿼리 키에 포함됨에 따라, 좋아요 낙관적 업데이트(`LikeButton`)와 삭제 무효화(`useDeleteMyProject`)가 모든 정렬 캐시에 적용되도록 정렬 무관 prefix 키(`getProjectsList`)로 변경.
- **레이아웃 정리**: 정렬 셀렉트 추가에 따른 `HeroSection`/`ProjectList` 좌측 정렬 어긋남 수정, 드롭다운이 항상 아래로 열리도록 overlay 처리.

## 스크린샷/동영상 📸

https://github.com/user-attachments/assets/16c773cf-ffd4-48ac-a5ca-204997360686

## 관련 이슈 🚨

- #72

## 리뷰 요청사항 👀

- URL `searchParams`를 source of truth로 두고 서버 prefetch + TanStack Query `initialData`를 함께 쓰는 구조가 적절한지 봐주세요. (정렬 변경마다 RSC 재실행 + 클라이언트 쿼리 키 변경)
- 쿼리 키에 `sort`가 포함되면서 좋아요/삭제 캐시 갱신을 prefix 키로 바꿨는데, 누락된 캐시 갱신 지점이 없는지 확인 부탁드립니다.
- 백엔드 기본 정렬이 `NEWEST`와 동일하다는 전제로 구현했습니다.
